### PR TITLE
feat: add Algolia site verification meta tag

### DIFF
--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -19,6 +19,13 @@ export const shared = defineConfig({
     ],
     ['link', {rel: 'icon', href: '/icon.png'}],
     ['link', {rel: 'manifest', href: '/manifest.webmanifest'}],
+    [
+      'meta',
+      {
+        name: 'algolia-site-verification',
+        content: '48C2DFC304B4DCF2',
+      },
+    ],
   ],
   themeConfig: {
     logo: '/icon-1024 2.png',


### PR DESCRIPTION
## Changes

Add `<meta name="algolia-site-verification" content="48C2DFC304B4DCF2" />` to the VitePress `head` config in `docs/.vitepress/config/shared.ts`.

This is required for Algolia site ownership verification.