### PR TITLE
feat: update Algolia search indexName to ham_docs_pages

### DIFF
--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -35,7 +35,7 @@ export const shared = defineConfig({
       options: {
         appId: '92H3AM2QST',
         apiKey: 'c509e924662c649625019c373a234990',
-        indexName: 'whu-ham',
+        indexName: 'ham_docs_pages',
         locales: {
           ...enSearch,
           ...jaSearch,

--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -19,6 +19,13 @@ export const shared = defineConfig({
     ],
     ['link', {rel: 'icon', href: '/icon.png'}],
     ['link', {rel: 'manifest', href: '/manifest.webmanifest'}],
+    [
+      'meta',
+      {
+        name: 'algolia-site-verification',
+        content: '48C2DFC304B4DCF2',
+      },
+    ],
   ],
   themeConfig: {
     logo: '/icon-1024 2.png',


### PR DESCRIPTION
## Changes

- Update Algolia search `indexName` from `whu-ham` to `ham_docs_pages` to match the correct Algolia index configuration.