### PR TITLE
docs: add score calculation documentation for ham-rn

### DIFF
--- a/docs/src/developers/ham-rn/score-calc.md
+++ b/docs/src/developers/ham-rn/score-calc.md
@@ -75,6 +75,90 @@ function calc(scoreListJson, userInfoJson) {
 }
 ```
 
+## 如何新增计算方式
+
+### 第一步：创建计算脚本
+
+在 `src/business/education/scorecalc/embed/` 目录下新建一个 `.ts` 文件，使用 `defineEmbed` 函数定义计算逻辑：
+
+```typescript
+import {defineEmbed} from '@/business/education/scorecalc/defineEmbed';
+
+defineEmbed((scoreList, userInfo) => {
+  // scoreList: ScoreJsItem[] — 成绩列表
+  // userInfo: UserInfo — 用户信息
+
+  // 在此编写你的计算逻辑
+  let totalWeighted = 0;
+  let totalCredit = 0;
+  const selectedIds: string[] = [];
+
+  for (const item of scoreList) {
+    totalWeighted += item.credit * item.score;
+    totalCredit += item.credit;
+    selectedIds.push(item.courseId);
+  }
+
+  const result = totalCredit > 0 ? totalWeighted / totalCredit : 0;
+
+  // 返回 [计算结果, 参与计算的课程ID列表]
+  return [result, selectedIds];
+});
+```
+
+### 第二步：了解可用字段
+
+`scoreList` 中每个元素（`ScoreJsItem`）包含以下字段：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `courseType` | `string` | 课程类别（如 "公共基础必修"） |
+| `name` | `string` | 课程名称（如 "高等数学"） |
+| `credit` | `number` | 学分 |
+| `courseCollege` | `string` | 开课学院 |
+| `instructor` | `string` | 授课教师 |
+| `score` | `number` | 成绩（数值） |
+| `courseId` | `string` | 课程唯一标识 |
+
+`userInfo`（`UserInfo`）包含以下字段：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `userCollege` | `string` | 用户所在学院（如 "计算机学院"） |
+
+### 第三步：注册脚本
+
+在 `src/business/education/scorecalc/fetch.ts` 的 `fetchScoreCalcFromLocal` 函数中添加新条目：
+
+```typescript
+import newScript from './embed/generated/your-script.generated';
+
+const fetchScoreCalcFromLocal = (): Array<ScoreCalcItem> => {
+  return [
+    // ... 已有条目
+    {
+      title: '你的计算方式名称',
+      date: '2026-01-01',
+      author: '作者名',
+      version: 1,
+      brief: '简短描述',
+      updateBrief: '更新说明',
+      desc: '详细描述',
+      type: 'APP',
+      url: 'https://raw.githubusercontent.com/whu-ham/ham-rn/main/src/business/education/scorecalc/embed/your-script.ts',
+      script: newScript,
+    },
+  ];
+};
+```
+
+### 注意事项
+
+- `defineEmbed` 会将你的计算函数注册到 `globalThis.calc`，供原生端 JavaScriptCore 调用。
+- 返回值必须是 `[number, string[]]` 格式，第一个元素是计算结果，第二个元素是参与计算的课程 ID 列表。
+- `embed/` 目录下的 `.ts` 文件会在构建时生成对应的 `.generated` 文件，供 `fetch.ts` 导入。
+- 你可以根据 `courseType` 字段筛选必修/选修课程，或根据 `userCollege` 实现学院特定的计算逻辑。
+
 ## 相关原生模块
 
 | 模块 | 说明 |

--- a/docs/src/en/developers/ham-rn/score-calc.md
+++ b/docs/src/en/developers/ham-rn/score-calc.md
@@ -75,6 +75,90 @@ function calc(scoreListJson, userInfoJson) {
 }
 ```
 
+## How to Add a New Calculation Method
+
+### Step 1: Create a Calculation Script
+
+Create a new `.ts` file under `src/business/education/scorecalc/embed/` and use the `defineEmbed` function to define your calculation logic:
+
+```typescript
+import {defineEmbed} from '@/business/education/scorecalc/defineEmbed';
+
+defineEmbed((scoreList, userInfo) => {
+  // scoreList: ScoreJsItem[] — list of course scores
+  // userInfo: UserInfo — user information
+
+  // Write your calculation logic here
+  let totalWeighted = 0;
+  let totalCredit = 0;
+  const selectedIds: string[] = [];
+
+  for (const item of scoreList) {
+    totalWeighted += item.credit * item.score;
+    totalCredit += item.credit;
+    selectedIds.push(item.courseId);
+  }
+
+  const result = totalCredit > 0 ? totalWeighted / totalCredit : 0;
+
+  // Return [calculated score, list of course IDs used in calculation]
+  return [result, selectedIds];
+});
+```
+
+### Step 2: Available Fields
+
+Each element (`ScoreJsItem`) in `scoreList` contains the following fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `courseType` | `string` | Course category (e.g. "公共基础必修") |
+| `name` | `string` | Course name (e.g. "高等数学") |
+| `credit` | `number` | Credit hours |
+| `courseCollege` | `string` | College offering the course |
+| `instructor` | `string` | Instructor name |
+| `score` | `number` | Numeric score |
+| `courseId` | `string` | Unique course identifier |
+
+`userInfo` (`UserInfo`) contains the following fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `userCollege` | `string` | User's college (e.g. "计算机学院") |
+
+### Step 3: Register the Script
+
+Add a new entry in the `fetchScoreCalcFromLocal` function in `src/business/education/scorecalc/fetch.ts`:
+
+```typescript
+import newScript from './embed/generated/your-script.generated';
+
+const fetchScoreCalcFromLocal = (): Array<ScoreCalcItem> => {
+  return [
+    // ... existing entries
+    {
+      title: 'Your Calculation Method Name',
+      date: '2026-01-01',
+      author: 'Author Name',
+      version: 1,
+      brief: 'Short description',
+      updateBrief: 'Update notes',
+      desc: 'Detailed description',
+      type: 'APP',
+      url: 'https://raw.githubusercontent.com/whu-ham/ham-rn/main/src/business/education/scorecalc/embed/your-script.ts',
+      script: newScript,
+    },
+  ];
+};
+```
+
+### Notes
+
+- `defineEmbed` registers your calculation function on `globalThis.calc`, making it callable from the native JSContext (e.g. iOS JavaScriptCore).
+- The return value must be in `[number, string[]]` format — the first element is the calculated score, the second is the list of course IDs that contributed to the calculation.
+- `.ts` files in the `embed/` directory are compiled into corresponding `.generated` files at build time, which are then imported by `fetch.ts`.
+- You can filter courses by `courseType` (e.g. required vs. elective), or implement college-specific logic using `userCollege`.
+
 ## Related Native Modules
 
 | Module | Description |

--- a/docs/src/ja/developers/ham-rn/score-calc.md
+++ b/docs/src/ja/developers/ham-rn/score-calc.md
@@ -75,6 +75,90 @@ function calc(scoreListJson, userInfoJson) {
 }
 ```
 
+## 新しい計算方法の追加方法
+
+### ステップ 1：計算スクリプトの作成
+
+`src/business/education/scorecalc/embed/` ディレクトリに新しい `.ts` ファイルを作成し、`defineEmbed` 関数を使って計算ロジックを定義します：
+
+```typescript
+import {defineEmbed} from '@/business/education/scorecalc/defineEmbed';
+
+defineEmbed((scoreList, userInfo) => {
+  // scoreList: ScoreJsItem[] — 成績リスト
+  // userInfo: UserInfo — ユーザー情報
+
+  // ここに計算ロジックを記述
+  let totalWeighted = 0;
+  let totalCredit = 0;
+  const selectedIds: string[] = [];
+
+  for (const item of scoreList) {
+    totalWeighted += item.credit * item.score;
+    totalCredit += item.credit;
+    selectedIds.push(item.courseId);
+  }
+
+  const result = totalCredit > 0 ? totalWeighted / totalCredit : 0;
+
+  // [計算結果, 計算に使用した科目IDリスト] を返す
+  return [result, selectedIds];
+});
+```
+
+### ステップ 2：利用可能なフィールド
+
+`scoreList` の各要素（`ScoreJsItem`）には以下のフィールドがあります：
+
+| フィールド | 型 | 説明 |
+| --- | --- | --- |
+| `courseType` | `string` | 科目カテゴリ（例："公共基础必修"） |
+| `name` | `string` | 科目名（例："高等数学"） |
+| `credit` | `number` | 単位数 |
+| `courseCollege` | `string` | 開講学部 |
+| `instructor` | `string` | 担当教員 |
+| `score` | `number` | 成績（数値） |
+| `courseId` | `string` | 科目の一意識別子 |
+
+`userInfo`（`UserInfo`）には以下のフィールドがあります：
+
+| フィールド | 型 | 説明 |
+| --- | --- | --- |
+| `userCollege` | `string` | ユーザーの所属学部（例："计算机学院"） |
+
+### ステップ 3：スクリプトの登録
+
+`src/business/education/scorecalc/fetch.ts` の `fetchScoreCalcFromLocal` 関数に新しいエントリを追加します：
+
+```typescript
+import newScript from './embed/generated/your-script.generated';
+
+const fetchScoreCalcFromLocal = (): Array<ScoreCalcItem> => {
+  return [
+    // ... 既存のエントリ
+    {
+      title: '計算方法の名前',
+      date: '2026-01-01',
+      author: '作者名',
+      version: 1,
+      brief: '簡単な説明',
+      updateBrief: '更新説明',
+      desc: '詳細な説明',
+      type: 'APP',
+      url: 'https://raw.githubusercontent.com/whu-ham/ham-rn/main/src/business/education/scorecalc/embed/your-script.ts',
+      script: newScript,
+    },
+  ];
+};
+```
+
+### 注意事項
+
+- `defineEmbed` は計算関数を `globalThis.calc` に登録し、ネイティブ側の JSContext（例：iOS JavaScriptCore）から呼び出し可能にします。
+- 戻り値は `[number, string[]]` 形式でなければなりません。最初の要素は計算結果、2番目の要素は計算に使用した科目IDのリストです。
+- `embed/` ディレクトリ内の `.ts` ファイルはビルド時に対応する `.generated` ファイルにコンパイルされ、`fetch.ts` からインポートされます。
+- `courseType` フィールドで必修/選択科目をフィルタリングしたり、`userCollege` を使って学部固有の計算ロジックを実装できます。
+
 ## 関連ネイティブモジュール
 
 | モジュール | 説明 |


### PR DESCRIPTION
## Changes

Add score calculation documentation for ham-rn module in three languages:

- 🇨🇳 Chinese (`docs/src/developers/ham-rn/score-calc.md`)
- 🇬🇧 English (`docs/src/en/developers/ham-rn/score-calc.md`)
- 🇯🇵 Japanese (`docs/src/ja/developers/ham-rn/score-calc.md`)

**+252 lines added across 3 files**