### PR TITLE
fix(docs): unify en/ja index logo with zh and reorder description

### DIFF
--- a/docs/src/en/index.md
+++ b/docs/src/en/index.md
@@ -1,11 +1,10 @@
 ---
-description: "Ham - A campus life assistant app for Wuhan University (WHU)."
 layout: home
 hero:
   name: Ham
   tagline: Documentation
   image:
-    src: ../images/icons/android-chrome-192x192.png
+    src: ../icon-1024 2.png
     alt: Ham-Logo
   actions:
     - theme: brand
@@ -45,4 +44,6 @@ features:
   - icon: 📅
     title: Schedule
     details: Add assignments with reminders, link to courses, and sync to iOS Calendar
+
+description: "Ham - A campus life assistant app for Wuhan University (WHU)."
 ---

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,4 @@
 ---
-description: "Ham - 武汉大学校园生活助手应用。"
 layout: home
 hero:
   name: Ham
@@ -45,4 +44,6 @@ features:
   - icon: 📅
     title: 日程
     details: 添加你的作业并支持到期提醒，支持关联课程，并同步到iOS日历
+
+description: "Ham - 武汉大学校园生活助手应用。"
 ---

--- a/docs/src/ja/index.md
+++ b/docs/src/ja/index.md
@@ -1,11 +1,10 @@
 ---
-description: "Ham - 武漢大学のキャンパスライフアシスタントアプリ。"
 layout: home
 hero:
   name: Ham
   tagline: ドキュメント
   image:
-    src: ../images/icons/android-chrome-192x192.png
+    src: ../icon-1024 2.png
     alt: Ham-Logo
   actions:
     - theme: brand
@@ -45,4 +44,6 @@ features:
   - icon: 📅
     title: 予定
     details: 課題を追加して期限前通知、授業に関連付け、iOSカレンダーに同期
+
+description: "Ham - 武漢大学のキャンパスライフアシスタントアプリ。"
 ---


### PR DESCRIPTION
## 背景

`en/index.md` 与 `ja/index.md` 之前使用的首页 logo 是 `android-chrome-192x192.png`，与中文版首页使用的 `icon-1024 2.png` 不一致，造成跨语言首页视觉风格差异。

## 修改内容

- 将 `docs/src/en/index.md` 和 `docs/src/ja/index.md` 的 `hero.image.src` 与 `heroImage` 统一指向 `icon-1024 2.png`（等价于中文首页使用的 logo）。
- 将三份首页中的 `description` 字段从 frontmatter 最前面移动到 `features` 后面，顺序更合理。

## 影响范围

仅文档首页（zh / en / ja）的 frontmatter，不影响页面结构与路由。
