### PR TITLE
docs(mcp): add OAuth dynamic registration & client config guides

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: 25.4.0
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
+        uses: pnpm/action-setup@v6
         with:
           version: 11.1.3
           run_install: true

--- a/.github/workflows/vitepress-deploy.yml
+++ b/.github/workflows/vitepress-deploy.yml
@@ -1,10 +1,8 @@
 name: docs
 
 on:
-  # 每当 push 到 main 分支时触发部署
   push:
     branches: [main]
-  # 手动触发部署
   workflow_dispatch:
 
 jobs:
@@ -20,7 +18,7 @@ jobs:
         with:
           node-version: 25.4.0
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: 11.1.3
           run_install: true

--- a/docs/src/developers/ham-web/index.md
+++ b/docs/src/developers/ham-web/index.md
@@ -68,7 +68,7 @@ app/                # Next.js App Router 入口
     auth/           # 认证相关 API（登录、登出、刷新、Passkey、二维码）
     sso/            # SSO 相关 API（授权确认、授权信息）
   sso-authorize/    # SSO 授权页面（登录视图、二维码登录、Passkey 登录）
-console/          # Web 控制台（API Key 管理、账户信息）
+  console/          # Web 控制台（API Key 管理、账户信息）
 components/         # 共享 UI 组件
   LanguageSwitcher  # 语言切换器
   ThemeSwitcher     # 主题切换器

--- a/docs/src/developers/ham-web/index.md
+++ b/docs/src/developers/ham-web/index.md
@@ -17,7 +17,7 @@ next:
 Ham Web 部署后作为 Ham 互联平台的 Web 服务端点，主要在以下场景中被使用：
 
 - **SSO 授权页面** — 当第三方应用通过 Ham 互联平台发起 OAuth2 授权时，用户会被重定向到 Ham Web 的授权页面进行登录和授权确认
-- **Web 控制台** — 用户可以在浏览器中管理 Token、查看账户信息等（[ham.nowcent.cn/console](https://ham.nowcent.cn/console)）
+- **Web 控制台** — 用户可以在浏览器中管理 API Key、查看账户信息等（[ham.nowcent.cn/console](https://ham.nowcent.cn/console)）
 - **二维码登录** — 用户可以在 Web 端通过扫描二维码完成登录
 - **Passkey 登录** — 支持 WebAuthn / Passkey 无密码登录
 - **移动端 H5 回退** — 当用户未安装 Ham 原生应用时，提供 Web 端的安装引导和 Passkey 登录选项
@@ -68,7 +68,7 @@ app/                # Next.js App Router 入口
     auth/           # 认证相关 API（登录、登出、刷新、Passkey、二维码）
     sso/            # SSO 相关 API（授权确认、授权信息）
   sso-authorize/    # SSO 授权页面（登录视图、二维码登录、Passkey 登录）
-  console/          # Web 控制台（Token 管理、账户信息）
+console/          # Web 控制台（API Key 管理、账户信息）
 components/         # 共享 UI 组件
   LanguageSwitcher  # 语言切换器
   ThemeSwitcher     # 主题切换器

--- a/docs/src/en/developers/ham-web/index.md
+++ b/docs/src/en/developers/ham-web/index.md
@@ -68,7 +68,7 @@ app/                # Next.js App Router entry
     auth/           # Auth APIs (login, logout, refresh, passkey, QR code)
     sso/            # SSO APIs (consent confirmation, consent info)
   sso-authorize/    # SSO authorization page (login view, QR login, passkey login)
-console/          # Web console (API Key management, account info)
+  console/          # Web console (API Key management, account info)
 components/         # Shared UI components
   LanguageSwitcher  # Language switcher
   ThemeSwitcher     # Theme switcher

--- a/docs/src/en/developers/ham-web/index.md
+++ b/docs/src/en/developers/ham-web/index.md
@@ -17,7 +17,7 @@ next:
 Once deployed, Ham Web serves as the web service endpoint for the Ham Connect platform. It is used in the following scenarios:
 
 - **SSO Authorization Page** — When third-party apps initiate OAuth2 authorization through the Ham Connect platform, users are redirected to Ham Web's authorization page for login and consent confirmation
-- **Web Console** — Users can manage Tokens, view account information, and more in the browser ([ham.nowcent.cn/console](https://ham.nowcent.cn/console))
+- **Web Console** — Users can manage API Keys, view account information, and more in the browser ([ham.nowcent.cn/console](https://ham.nowcent.cn/console))
 - **QR Code Login** — Users can log in on the web by scanning a QR code with the Ham app
 - **Passkey Login** — Supports WebAuthn / Passkey passwordless login
 - **Mobile H5 Fallback** — When users don't have the Ham native app installed, provides a web-based install prompt and Passkey login option
@@ -68,7 +68,7 @@ app/                # Next.js App Router entry
     auth/           # Auth APIs (login, logout, refresh, passkey, QR code)
     sso/            # SSO APIs (consent confirmation, consent info)
   sso-authorize/    # SSO authorization page (login view, QR login, passkey login)
-  console/          # Web console (Token management, account info)
+console/          # Web console (API Key management, account info)
 components/         # Shared UI components
   LanguageSwitcher  # Language switcher
   ThemeSwitcher     # Theme switcher

--- a/docs/src/en/guide/mcp/config.md
+++ b/docs/src/en/guide/mcp/config.md
@@ -112,38 +112,22 @@ ChatGPT Connectors are currently available only to ChatGPT Plus / Pro / Business
 
 #### Option 1: OAuth Dynamic Registration (recommended)
 
-1. Open Cursor Settings (`Cmd + ,`)
-2. Go to **MCP & Integrations** and click **New MCP Server**
-3. Use the configuration:
-   ```json
-   {
-     "mcpServers": {
-       "ham": {
-         "type": "streamable-http",
-         "url": "https://mcp.ham.nowcent.cn/mcp"
-       }
-     }
-   }
-   ```
-4. Save — Cursor will open your browser to complete the OAuth flow.
+1. Open Cursor Settings (`Cmd + ,`) and go to **MCP & Integrations**
+2. Click **New MCP Server** and fill in the dialog:
+   - **Name**: `ham`
+   - **Type**: `SSE`
+   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
+3. Save — Cursor will open your browser to complete the OAuth flow.
 
 #### Option 2: API Key
 
-Add a `headers` field to the configuration:
+In the **New MCP Server** dialog, fill in Name / Type / URL as above, then add a row under **Headers**:
 
-```json
-{
-  "mcpServers": {
-    "ham": {
-      "type": "streamable-http",
-      "url": "https://mcp.ham.nowcent.cn/mcp",
-      "headers": {
-        "Authorization": "Bearer <YOUR_API_KEY>"
-      }
-    }
-  }
-}
-```
+| Key | Value |
+| --- | --- |
+| `Authorization` | `Bearer <YOUR_API_KEY>` |
+
+Save to apply.
 
 ### [Antigravity](https://antigravity.google/)
 

--- a/docs/src/en/guide/mcp/config.md
+++ b/docs/src/en/guide/mcp/config.md
@@ -87,8 +87,8 @@ ChatGPT Connectors are currently available only to ChatGPT Plus / Pro / Business
 
 ### [WorkBuddy](https://www.codebuddy.cn/work/)
 
-1. Open WorkBuddy and go to **Settings → MCP Marketplace → Custom MCP**
-2. Choose **Add MCP Server** and fill in:
+1. Open WorkBuddy and go to **Connectors → Custom Connector → Configure MCP**
+2. Fill in the following configuration:
    ```json
    {
      "mcpServers": {
@@ -112,22 +112,37 @@ ChatGPT Connectors are currently available only to ChatGPT Plus / Pro / Business
 
 #### Option 1: OAuth Dynamic Registration (recommended)
 
-1. Open Cursor Settings (`Cmd + ,`) and go to **MCP & Integrations**
-2. Click **New MCP Server** and fill in the dialog:
-   - **Name**: `ham`
-   - **Type**: `SSE`
-   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
+1. Open Cursor Settings (`Cmd + ,`) and go to **Tools & MCPs**
+2. Click **New MCP Server** — Cursor opens a new window (`mcp.json`) where you paste the configuration. Paste:
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
 3. Save — Cursor will open your browser to complete the OAuth flow.
 
 #### Option 2: API Key
 
-In the **New MCP Server** dialog, fill in Name / Type / URL as above, then add a row under **Headers**:
+Add a `headers.Authorization` field to the configuration:
 
-| Key | Value |
-| --- | --- |
-| `Authorization` | `Bearer <YOUR_API_KEY>` |
-
-Save to apply.
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "type": "streamable-http",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
 
 ### [Antigravity](https://antigravity.google/)
 

--- a/docs/src/en/guide/mcp/config.md
+++ b/docs/src/en/guide/mcp/config.md
@@ -1,5 +1,5 @@
 ---
-description: "Ham MCP service configuration guide — Configure Ham MCP in Claude Desktop, Cursor, and other clients."
+description: "Ham MCP service configuration guide — Configure Ham MCP in Claude, ChatGPT, Cherry Studio, Cursor, Antigravity, Claude Code, Codex, and more."
 prev:
   text: 'MCP Introduction'
   link: '/en/guide/mcp/'
@@ -15,16 +15,31 @@ This guide explains how to configure Ham MCP service in common MCP clients.
 | --- | --- |
 | Transport | Streamable HTTP |
 | Service URL | `https://mcp.ham.nowcent.cn/mcp` |
-| Authentication | Bearer Token |
+| Authentication | OAuth Dynamic Registration (recommended) / API Key |
 
-## Claude Desktop
+::: tip
+For clients that support OAuth dynamic registration, you only need to fill in the service URL and the rest is handled automatically. See [MCP Introduction - OAuth Dynamic Registration](/en/guide/mcp/#oauth-dynamic-registration-recommended).
+:::
 
-Edit the Claude Desktop configuration file:
+## Desktop Apps
+
+### [Claude](https://claude.ai/)
+
+#### Option 1: OAuth Dynamic Registration (recommended)
+
+1. Open Claude and go to **Settings → Connectors**
+2. Click **Add custom connector**
+3. Fill in:
+   - **Name**: `Ham`
+   - **Remote MCP server URL**: `https://mcp.ham.nowcent.cn/mcp`
+4. Click **Connect**. Your browser will open the Ham authorization page; sign in and approve to complete the setup.
+
+#### Option 2: API Key (desktop app only)
+
+The desktop app supports API Key via the configuration file:
 
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-Add the following configuration:
 
 ```json
 {
@@ -33,33 +48,272 @@ Add the following configuration:
       "type": "streamable-http",
       "url": "https://mcp.ham.nowcent.cn/mcp",
       "headers": {
-        "Authorization": "Bearer <YOUR_TOKEN>"
+        "Authorization": "Bearer <YOUR_API_KEY>"
       }
     }
   }
 }
 ```
 
-Replace `<YOUR_TOKEN>` with the Token you generated in the [Ham Console](https://ham.nowcent.cn/console/tokens).
+Replace `<YOUR_API_KEY>` with the API Key generated from the [Ham Console](https://ham.nowcent.cn/console/tokens), then restart Claude.
 
-Restart Claude Desktop after saving for the changes to take effect.
+### [ChatGPT](https://chatgpt.com/)
 
-## Cursor
+1. Open ChatGPT and go to **Settings → Connectors → Advanced**
+2. Enable **Developer mode**
+3. Return to the Connectors page and click **Create**
+4. Fill in:
+   - **Name**: `Ham`
+   - **MCP Server URL**: `https://mcp.ham.nowcent.cn/mcp`
+   - **Authentication**: `OAuth`
+5. Click **Create** — you will be redirected to the Ham authorization page. After approval, the connector is ready to use in chats.
 
-To configure the MCP service in Cursor:
+::: tip
+ChatGPT Connectors are currently available only to ChatGPT Plus / Pro / Business / Enterprise users.
+:::
+
+### [Cherry Studio](https://cherry-ai.com/)
+
+1. Open Cherry Studio and go to **Settings → MCP Servers → Add Server**
+2. Fill in:
+   - **Name**: `Ham`
+   - **Type**: `Streamable HTTP`
+   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
+3. Save and enable the server. The first tool call opens your browser to complete the OAuth flow.
+4. To use an API Key, add a header in **Headers**:
+   ```
+   Authorization=Bearer <YOUR_API_KEY>
+   ```
+
+### [WorkBuddy](https://www.codebuddy.cn/work/)
+
+1. Open WorkBuddy and go to **Settings → MCP Marketplace → Custom MCP**
+2. Choose **Add MCP Server** and fill in:
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+3. Save — your browser will open to complete the OAuth flow. To use an API Key instead, add a `headers.Authorization` field:
+   ```json
+   "headers": {
+     "Authorization": "Bearer <YOUR_API_KEY>"
+   }
+   ```
+
+## IDEs & Editors
+
+### [Cursor](https://cursor.com/)
+
+#### Option 1: OAuth Dynamic Registration (recommended)
 
 1. Open Cursor Settings (`Cmd + ,`)
-2. Navigate to the **MCP** section
-3. Click **Add new MCP server**
-4. Fill in the configuration:
-   - **Name**: `Ham`
-   - **Type**: `streamable-http`
-   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
-5. Add authentication in Headers:
-   - **Key**: `Authorization`
-   - **Value**: `Bearer <YOUR_TOKEN>`
+2. Go to **MCP & Integrations** and click **New MCP Server**
+3. Use the configuration:
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+4. Save — Cursor will open your browser to complete the OAuth flow.
 
-Replace `<YOUR_TOKEN>` with your actual Token.
+#### Option 2: API Key
+
+Add a `headers` field to the configuration:
+
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "type": "streamable-http",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### [Antigravity](https://antigravity.google/)
+
+1. Open Antigravity and go to **Settings → MCP Servers**
+2. Click **Add custom MCP server** and fill in:
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+3. Save — your browser will open the Ham authorization page to complete the OAuth flow.
+4. To use an API Key, simply add a `headers.Authorization` field.
+
+### [CodeBuddy](https://copilot.tencent.com/)
+
+1. Open the CodeBuddy panel and click **Settings → MCP Marketplace → Custom MCP**
+2. Choose **Add MCP Server** and fill in:
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+3. Save — your browser will open to complete the OAuth flow. To use an API Key instead, add a `headers.Authorization` field:
+   ```json
+   "headers": {
+     "Authorization": "Bearer <YOUR_API_KEY>"
+   }
+   ```
+
+## CLI Tools
+
+### [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+
+Run the following command in your terminal to add the Ham MCP service (uses OAuth dynamic registration automatically):
+
+```bash
+claude mcp add --transport http ham https://mcp.ham.nowcent.cn/mcp
+```
+
+The browser will open for authorization on first use. To use an API Key instead:
+
+```bash
+claude mcp add --transport http ham https://mcp.ham.nowcent.cn/mcp \
+  --header "Authorization: Bearer <YOUR_API_KEY>"
+```
+
+### [Codex](https://github.com/openai/codex)
+
+Configure MCP servers via `~/.codex/config.toml`.
+
+#### Option 1: OAuth Dynamic Registration (recommended)
+
+```toml
+[mcp_servers.ham]
+url = "https://mcp.ham.nowcent.cn/mcp"
+```
+
+The browser will open for authorization the first time you run `codex`.
+
+#### Option 2: API Key
+
+```toml
+[mcp_servers.ham]
+url = "https://mcp.ham.nowcent.cn/mcp"
+
+[mcp_servers.ham.headers]
+Authorization = "Bearer <YOUR_API_KEY>"
+```
+
+### [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+
+Configure MCP servers via `~/.gemini/settings.json` (user-level) or `.gemini/settings.json` in the project root (project-level).
+
+#### Option 1: OAuth Dynamic Registration (recommended)
+
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "httpUrl": "https://mcp.ham.nowcent.cn/mcp"
+    }
+  }
+}
+```
+
+The browser will open for authorization on first tool invocation.
+
+#### Option 2: API Key
+
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "httpUrl": "https://mcp.ham.nowcent.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### [OpenCode](https://opencode.ai/)
+
+Configure MCP servers via the project root or `~/.config/opencode/opencode.json`.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "ham": {
+      "type": "remote",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+The browser will open for authorization the first time you run `opencode`. To use an API Key instead:
+
+```json
+{
+  "mcp": {
+    "ham": {
+      "type": "remote",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "enabled": true,
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### [OpenClaw](https://openclaw.ai/)
+
+#### Option 1: Add via Chat (recommended)
+
+In the OpenClaw chat, simply say:
+
+```
+Please add an MCP server named "ham" at https://mcp.ham.nowcent.cn/mcp using streamable HTTP transport with OAuth dynamic registration.
+```
+
+OpenClaw will write the configuration automatically and open the browser to complete the OAuth flow.
+
+#### Option 2: CLI Command
+
+```bash
+openclaw mcp add ham --transport http --url https://mcp.ham.nowcent.cn/mcp
+```
+
+To use an API Key instead:
+
+```bash
+openclaw mcp add ham --transport http --url https://mcp.ham.nowcent.cn/mcp \
+  --header "Authorization: Bearer <YOUR_API_KEY>"
+```
 
 ## Other MCP Clients
 
@@ -67,27 +321,6 @@ For other MCP-compatible clients, the general configuration steps are:
 
 1. Select **Streamable HTTP** transport
 2. Set the service URL to `https://mcp.ham.nowcent.cn/mcp`
-3. Add `Authorization: Bearer <YOUR_TOKEN>` to the request headers
+3. Prefer the client's built-in OAuth flow; if unsupported, add `Authorization: Bearer <YOUR_API_KEY>` to request headers
 
 Refer to your client's documentation for specific configuration instructions.
-
-## Troubleshooting
-
-### Connection Failed
-
-- Verify the service URL is correct: `https://mcp.ham.nowcent.cn/mcp`
-- Check your network connection
-- Confirm your client supports Streamable HTTP transport
-
-### Authentication Failed
-
-- Verify your Token is correct, including the `Bearer` prefix
-- Check if your Token has expired in the [Ham Console](https://ham.nowcent.cn/console/tokens)
-- If your Token has been compromised, delete it immediately in the console and generate a new one
-
-### Token Security
-
-- Never commit Tokens to code repositories
-- Never share Tokens in public channels
-- Rotate Tokens regularly
-- Create separate Tokens for different clients for easier management

--- a/docs/src/en/guide/mcp/index.md
+++ b/docs/src/en/guide/mcp/index.md
@@ -26,21 +26,38 @@ https://mcp.ham.nowcent.cn/mcp
 
 ## Authentication
 
-Ham MCP service uses **Bearer Token** authentication. You need to generate a Token in the Ham console and use it in your MCP client configuration.
+Ham MCP service supports two authentication methods:
 
-### Getting a Token
+- **OAuth Dynamic Registration (recommended)**: The client automatically completes registration and authorization on first connection — no manual API Key creation required. Suitable for modern MCP-OAuth-capable clients (Claude Desktop, Cursor, ChatGPT, Codex, etc.).
+- **API Key**: Manually generate an API Key in the Ham console and authenticate via the `Authorization: Bearer <API_KEY>` request header — suitable for clients that do not support OAuth dynamic registration, or when a long-lived credential is needed.
 
-1. Visit [Ham Console - Token Management](https://ham.nowcent.cn/console/tokens)
-2. Click "Create Token"
-3. Add a description for the Token (e.g., "Claude Desktop") for easy management
-4. Copy the generated Token (**shown only once, keep it safe**)
+### OAuth Dynamic Registration (recommended)
 
-::: warning
-Do not share your Token with others. A Token is equivalent to your account credentials — leakage may result in unauthorized access to your personal information.
+Ham MCP service follows the [MCP Authorization specification](https://modelcontextprotocol.io/specification/draft/basic/authorization), implementing [OAuth 2.0 Dynamic Client Registration (RFC 7591)](https://datatracker.ietf.org/doc/html/rfc7591) and [Protected Resource Metadata (RFC 9728)](https://datatracker.ietf.org/doc/html/rfc9728).
+
+The integration flow is fully handled by the client:
+
+1. The client requests the service URL and receives a `401 Unauthorized` response.
+2. The client discovers the authorization server via `/.well-known/oauth-protected-resource`.
+3. The client registers itself dynamically and obtains a `client_id`.
+4. The browser opens the Ham authorization page; after sign-in and consent, the user is redirected back.
+5. The client receives an access token and automatically attaches it to subsequent requests — no manual configuration needed.
+
+::: tip
+With dynamic registration, you only need to fill in the service URL `https://mcp.ham.nowcent.cn/mcp` in your client. Everything else is handled automatically.
 :::
 
-## Next Steps
+### API Key
 
-Learn how to configure Ham MCP service in various MCP clients:
+If your client does not support OAuth dynamic registration, or you prefer a long-lived static credential, generate an API Key in the Ham console and configure it manually.
 
-[Configuration Guide →](/en/guide/mcp/config)
+#### Getting an API Key
+
+1. Visit [Ham Console - API Keys](https://ham.nowcent.cn/console/tokens)
+2. Click "Create API Key"
+3. Add a description for the API Key (e.g., "Claude Desktop") for easy management
+4. Copy the generated API Key (**shown only once, keep it safe**)
+
+::: warning
+Do not share your API Key with others. An API Key is equivalent to your account credentials — leakage may result in unauthorized access to your personal information.
+:::

--- a/docs/src/guide/mcp/config.md
+++ b/docs/src/guide/mcp/config.md
@@ -112,38 +112,22 @@ ChatGPT 的 Connectors 功能目前仅对 ChatGPT Plus / Pro / Business / Enterp
 
 #### 方式一：OAuth 动态注册（推荐）
 
-1. 打开 Cursor 设置（`Cmd + ,`）
-2. 进入 **MCP & Integrations**，点击 **New MCP Server**
-3. 填写配置：
-   ```json
-   {
-     "mcpServers": {
-       "ham": {
-         "type": "streamable-http",
-         "url": "https://mcp.ham.nowcent.cn/mcp"
-       }
-     }
-   }
-   ```
-4. 保存后 Cursor 会自动唤起浏览器完成授权。
+1. 打开 Cursor 设置（`Cmd + ,`），进入 **MCP & Integrations**
+2. 点击 **New MCP Server**，在弹出对话框中填写：
+   - **Name**: `ham`
+   - **Type**: `SSE`
+   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
+3. 保存后 Cursor 会自动唤起浏览器完成 OAuth 授权。
 
 #### 方式二：API Key
 
-在配置中添加 `headers` 字段：
+在 **New MCP Server** 对话框中按上述方式填写 Name / Type / URL，并在 **Headers** 区域添加一行：
 
-```json
-{
-  "mcpServers": {
-    "ham": {
-      "type": "streamable-http",
-      "url": "https://mcp.ham.nowcent.cn/mcp",
-      "headers": {
-        "Authorization": "Bearer <YOUR_API_KEY>"
-      }
-    }
-  }
-}
-```
+| Key | Value |
+| --- | --- |
+| `Authorization` | `Bearer <YOUR_API_KEY>` |
+
+保存后即可使用。
 
 ### [Antigravity](https://antigravity.google/)
 

--- a/docs/src/guide/mcp/config.md
+++ b/docs/src/guide/mcp/config.md
@@ -87,8 +87,8 @@ ChatGPT 的 Connectors 功能目前仅对 ChatGPT Plus / Pro / Business / Enterp
 
 ### [WorkBuddy](https://www.codebuddy.cn/work/)
 
-1. 打开 WorkBuddy，进入 **设置 → MCP 市场 → 自定义 MCP**
-2. 选择 **添加 MCP 服务**，填写：
+1. 打开 WorkBuddy，进入 **连接器 → 自定义连接器 → 配置 MCP**
+2. 填写以下配置：
    ```json
    {
      "mcpServers": {
@@ -112,22 +112,37 @@ ChatGPT 的 Connectors 功能目前仅对 ChatGPT Plus / Pro / Business / Enterp
 
 #### 方式一：OAuth 动态注册（推荐）
 
-1. 打开 Cursor 设置（`Cmd + ,`），进入 **MCP & Integrations**
-2. 点击 **New MCP Server**，在弹出对话框中填写：
-   - **Name**: `ham`
-   - **Type**: `SSE`
-   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
+1. 打开 Cursor 设置（`Cmd + ,`），进入 **Tools & MCPs**
+2. 点击 **New MCP Server**，Cursor 会打开一个新窗口（`mcp.json`）让你粘贴配置，将以下内容粘贴进去：
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
 3. 保存后 Cursor 会自动唤起浏览器完成 OAuth 授权。
 
 #### 方式二：API Key
 
-在 **New MCP Server** 对话框中按上述方式填写 Name / Type / URL，并在 **Headers** 区域添加一行：
+在配置中追加 `headers.Authorization`：
 
-| Key | Value |
-| --- | --- |
-| `Authorization` | `Bearer <YOUR_API_KEY>` |
-
-保存后即可使用。
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "type": "streamable-http",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
 
 ### [Antigravity](https://antigravity.google/)
 

--- a/docs/src/guide/mcp/config.md
+++ b/docs/src/guide/mcp/config.md
@@ -1,5 +1,5 @@
 ---
-description: "Ham MCP 服务配置指南 — 在 Claude Desktop、Cursor 等客户端中配置 Ham MCP。"
+description: "Ham MCP 服务配置指南 — 在 Claude、ChatGPT、Cherry Studio、Cursor、Antigravity、Claude Code、Codex 等客户端中配置 Ham MCP。"
 prev:
   text: 'MCP 介绍'
   link: '/guide/mcp/'
@@ -15,16 +15,31 @@ prev:
 | --- | --- |
 | 传输方式 | Streamable HTTP |
 | 服务地址 | `https://mcp.ham.nowcent.cn/mcp` |
-| 认证方式 | Bearer Token |
+| 认证方式 | OAuth 动态注册（推荐） / API Key |
 
-## Claude Desktop
+::: tip
+对于支持 OAuth 动态注册的客户端，你只需填入服务地址，其余流程会自动完成。详见 [MCP 介绍 - OAuth 动态注册](/guide/mcp/#oauth-动态注册推荐)。
+:::
 
-编辑 Claude Desktop 配置文件：
+## 桌面客户端
+
+### [Claude](https://claude.ai/)
+
+#### 方式一：OAuth 动态注册（推荐）
+
+1. 打开 Claude，进入 **Settings → Connectors**
+2. 点击 **Add custom connector**
+3. 填写：
+   - **Name**: `Ham`
+   - **Remote MCP server URL**: `https://mcp.ham.nowcent.cn/mcp`
+4. 保存后点击 **Connect**，浏览器会自动跳转至 Ham 授权页面，登录并同意授权后即可使用。
+
+#### 方式二：API Key（仅桌面版）
+
+桌面版可通过编辑配置文件使用 API Key：
 
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-添加以下配置：
 
 ```json
 {
@@ -33,33 +48,272 @@ prev:
       "type": "streamable-http",
       "url": "https://mcp.ham.nowcent.cn/mcp",
       "headers": {
-        "Authorization": "Bearer <YOUR_TOKEN>"
+        "Authorization": "Bearer <YOUR_API_KEY>"
       }
     }
   }
 }
 ```
 
-将 `<YOUR_TOKEN>` 替换为你在 [Ham 控制台](https://ham.nowcent.cn/console/tokens) 生成的 Token。
+将 `<YOUR_API_KEY>` 替换为你在 [Ham 控制台](https://ham.nowcent.cn/console/tokens) 生成的 API Key，保存后重启 Claude。
 
-保存后重启 Claude Desktop 即可生效。
+### [ChatGPT](https://chatgpt.com/)
 
-## Cursor
+1. 打开 ChatGPT，进入 **Settings → Connectors → Advanced**
+2. 启用 **Developer mode**（开发者模式）
+3. 返回 Connectors 页面，点击 **Create**
+4. 填写：
+   - **Name**: `Ham`
+   - **MCP Server URL**: `https://mcp.ham.nowcent.cn/mcp`
+   - **Authentication**: `OAuth`
+5. 点击 **Create** 后会跳转至 Ham 授权页面，完成授权即可在对话中使用。
 
-在 Cursor 中配置 MCP 服务：
+::: tip
+ChatGPT 的 Connectors 功能目前仅对 ChatGPT Plus / Pro / Business / Enterprise 用户开放。
+:::
+
+### [Cherry Studio](https://cherry-ai.com/)
+
+1. 打开 Cherry Studio，进入 **设置 → MCP 服务器 → 添加服务器**
+2. 填写：
+   - **名称**: `Ham`
+   - **类型**: `可流式传输的 HTTP（streamableHttp）`
+   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
+3. 保存后启用该服务器。首次调用工具时会自动唤起浏览器完成 OAuth 授权。
+4. 如需使用 API Key，在「请求头（Headers）」中添加：
+   ```
+   Authorization=Bearer <YOUR_API_KEY>
+   ```
+
+### [WorkBuddy](https://www.codebuddy.cn/work/)
+
+1. 打开 WorkBuddy，进入 **设置 → MCP 市场 → 自定义 MCP**
+2. 选择 **添加 MCP 服务**，填写：
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+3. 保存后会自动唤起浏览器完成 OAuth 授权；如需使用 API Key，在配置中追加 `headers.Authorization`：
+   ```json
+   "headers": {
+     "Authorization": "Bearer <YOUR_API_KEY>"
+   }
+   ```
+
+## IDE 与编辑器
+
+### [Cursor](https://cursor.com/)
+
+#### 方式一：OAuth 动态注册（推荐）
 
 1. 打开 Cursor 设置（`Cmd + ,`）
-2. 导航到 **MCP** 部分
-3. 点击 **Add new MCP server**
-4. 填写配置：
-   - **Name**: `Ham`
-   - **Type**: `streamable-http`
-   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
-5. 在 Headers 中添加认证信息：
-   - **Key**: `Authorization`
-   - **Value**: `Bearer <YOUR_TOKEN>`
+2. 进入 **MCP & Integrations**，点击 **New MCP Server**
+3. 填写配置：
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+4. 保存后 Cursor 会自动唤起浏览器完成授权。
 
-将 `<YOUR_TOKEN>` 替换为你的实际 Token。
+#### 方式二：API Key
+
+在配置中添加 `headers` 字段：
+
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "type": "streamable-http",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### [Antigravity](https://antigravity.google/)
+
+1. 打开 Antigravity，进入 **Settings → MCP Servers**
+2. 点击 **Add custom MCP server**，填写：
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+3. 保存后浏览器会自动打开 Ham 授权页面完成 OAuth 流程。
+4. 如需使用 API Key，添加 `headers.Authorization` 字段即可。
+
+### [CodeBuddy](https://copilot.tencent.com/)
+
+1. 打开 CodeBuddy 插件面板，点击右上角 **设置 → MCP 市场 → 自定义 MCP**
+2. 选择 **添加 MCP 服务**，填写：
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+3. 保存后会自动唤起浏览器完成 OAuth 授权；如需手动鉴权，可在配置中追加 `headers.Authorization`：
+   ```json
+   "headers": {
+     "Authorization": "Bearer <YOUR_API_KEY>"
+   }
+   ```
+
+## 命令行工具
+
+### [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+
+在终端中运行以下命令，添加 Ham MCP 服务（自动走 OAuth 动态注册）：
+
+```bash
+claude mcp add --transport http ham https://mcp.ham.nowcent.cn/mcp
+```
+
+首次调用时会自动打开浏览器完成授权。如需使用 API Key：
+
+```bash
+claude mcp add --transport http ham https://mcp.ham.nowcent.cn/mcp \
+  --header "Authorization: Bearer <YOUR_API_KEY>"
+```
+
+### [Codex](https://github.com/openai/codex)
+
+通过 `~/.codex/config.toml` 配置 MCP 服务。
+
+#### 方式一：OAuth 动态注册（推荐）
+
+```toml
+[mcp_servers.ham]
+url = "https://mcp.ham.nowcent.cn/mcp"
+```
+
+首次运行 `codex` 时会自动打开浏览器完成授权。
+
+#### 方式二：API Key
+
+```toml
+[mcp_servers.ham]
+url = "https://mcp.ham.nowcent.cn/mcp"
+
+[mcp_servers.ham.headers]
+Authorization = "Bearer <YOUR_API_KEY>"
+```
+
+### [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+
+通过 `~/.gemini/settings.json`（用户级）或项目根目录的 `.gemini/settings.json`（项目级）配置 MCP 服务。
+
+#### 方式一：OAuth 动态注册（推荐）
+
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "httpUrl": "https://mcp.ham.nowcent.cn/mcp"
+    }
+  }
+}
+```
+
+首次调用工具时会自动打开浏览器完成授权。
+
+#### 方式二：API Key
+
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "httpUrl": "https://mcp.ham.nowcent.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### [OpenCode](https://opencode.ai/)
+
+通过项目根目录或 `~/.config/opencode/opencode.json` 配置 MCP 服务。
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "ham": {
+      "type": "remote",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+首次运行 `opencode` 时会自动打开浏览器完成 OAuth 授权。如需使用 API Key：
+
+```json
+{
+  "mcp": {
+    "ham": {
+      "type": "remote",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "enabled": true,
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### [OpenClaw](https://openclaw.ai/)
+
+#### 方式一：对话添加（推荐）
+
+直接在 OpenClaw 对话中输入：
+
+```
+帮我添加一个 MCP 服务，名称是 ham，地址是 https://mcp.ham.nowcent.cn/mcp，使用 streamable HTTP 传输和 OAuth 动态注册。
+```
+
+OpenClaw 会自动写入配置并唤起浏览器完成 OAuth 授权。
+
+#### 方式二：CLI 命令
+
+```bash
+openclaw mcp add ham --transport http --url https://mcp.ham.nowcent.cn/mcp
+```
+
+如需使用 API Key：
+
+```bash
+openclaw mcp add ham --transport http --url https://mcp.ham.nowcent.cn/mcp \
+  --header "Authorization: Bearer <YOUR_API_KEY>"
+```
 
 ## 其他 MCP 客户端
 
@@ -67,27 +321,6 @@ prev:
 
 1. 选择 **Streamable HTTP** 传输方式
 2. 设置服务地址为 `https://mcp.ham.nowcent.cn/mcp`
-3. 在请求头中添加 `Authorization: Bearer <YOUR_TOKEN>`
+3. 优先使用客户端自带的 OAuth 流程；若不支持，则在请求头中添加 `Authorization: Bearer <YOUR_API_KEY>`
 
 具体配置方式请参考你所使用的客户端文档。
-
-## 常见问题
-
-### 连接失败
-
-- 确认服务地址正确：`https://mcp.ham.nowcent.cn/mcp`
-- 检查网络连接是否正常
-- 确认客户端支持 Streamable HTTP 传输方式
-
-### 认证失败
-
-- 检查 Token 是否正确，确保包含完整的 `Bearer` 前缀
-- 确认 Token 未过期，可在 [Ham 控制台](https://ham.nowcent.cn/console/tokens) 查看
-- 如果 Token 泄露，请立即在控制台删除并重新生成
-
-### Token 安全
-
-- 不要将 Token 提交到代码仓库
-- 不要在公开场合分享 Token
-- 定期轮换 Token
-- 为不同客户端创建独立的 Token，便于管理

--- a/docs/src/guide/mcp/index.md
+++ b/docs/src/guide/mcp/index.md
@@ -26,21 +26,38 @@ https://mcp.ham.nowcent.cn/mcp
 
 ## 认证方式
 
-Ham MCP 服务使用 **Bearer Token** 进行身份认证。你需要在 Ham 控制台生成 Token 后，在 MCP 客户端配置中使用。
+Ham MCP 服务支持两种认证方式：
 
-### 获取 Token
+- **OAuth 动态注册（推荐）**：客户端在首次连接时自动完成注册与授权，无需手动创建 API Key，适用于支持 MCP OAuth 的现代客户端（如 Claude Desktop、Cursor、ChatGPT、Codex 等）。
+- **API Key**：在 Ham 控制台手动生成 API Key，通过 `Authorization: Bearer <API_KEY>` 请求头进行鉴权，适用于不支持 OAuth 动态注册或需要长期凭证的场景。
 
-1. 访问 [Ham 控制台 - Token 管理](https://ham.nowcent.cn/console/tokens)
-2. 点击「创建 Token」
-3. 为 Token 添加描述（如「Claude Desktop」），方便后续管理
-4. 复制生成的 Token（**仅显示一次，请妥善保管**）
+### OAuth 动态注册（推荐）
 
-::: warning
-请勿将 Token 分享给他人。Token 等同于你的账号凭证，泄露可能导致个人信息被访问。
+Ham MCP 服务遵循 [MCP Authorization 规范](https://modelcontextprotocol.io/specification/draft/basic/authorization)，实现了 [OAuth 2.0 动态客户端注册（RFC 7591）](https://datatracker.ietf.org/doc/html/rfc7591) 与 [受保护资源元数据（RFC 9728）](https://datatracker.ietf.org/doc/html/rfc9728)。
+
+接入流程由客户端自动完成：
+
+1. 客户端访问服务地址，收到 `401 Unauthorized` 响应；
+2. 客户端通过 `/.well-known/oauth-protected-resource` 发现授权服务器；
+3. 客户端通过动态注册接口自动注册，获取 `client_id`；
+4. 浏览器跳转至 Ham 授权页面，登录并同意授权后返回客户端；
+5. 客户端获得访问凭证，后续请求自动携带，无需手动配置。
+
+::: tip
+使用动态注册时，你只需在客户端中填入服务地址 `https://mcp.ham.nowcent.cn/mcp`，其余流程均由客户端自动处理。
 :::
 
-## 下一步
+### API Key
 
-了解如何在各个 MCP 客户端中配置 Ham MCP 服务：
+如果你的客户端不支持 OAuth 动态注册，或希望使用长期固定凭证，可以在 Ham 控制台生成 API Key 后手动配置。
 
-[配置指南 →](/guide/mcp/config)
+#### 获取 API Key
+
+1. 访问 [Ham 控制台 - API Keys 管理](https://ham.nowcent.cn/console/tokens)
+2. 点击「创建 API Key」
+3. 为 API Key 添加描述（如「Claude Desktop」），方便后续管理
+4. 复制生成的 API Key（**仅显示一次，请妥善保管**）
+
+::: warning
+请勿将 API Key 分享给他人。API Key 等同于你的账号凭证，泄露可能导致个人信息被访问。
+:::

--- a/docs/src/ja/developers/ham-web/index.md
+++ b/docs/src/ja/developers/ham-web/index.md
@@ -17,7 +17,7 @@ next:
 Ham Web はデプロイ後、Ham Connect プラットフォームの Web サービスエンドポイントとして機能します。主に以下のシナリオで使用されます：
 
 - **SSO 認証ページ** — サードパーティアプリが Ham Connect プラットフォームを通じて OAuth2 認証を開始すると、ユーザーは Ham Web の認証ページにリダイレクトされ、ログインと同意確認を行います
-- **Web コンソール** — ブラウザで Token の管理、アカウント情報の確認などが可能（[ham.nowcent.cn/console](https://ham.nowcent.cn/console)）
+- **Web コンソール** — ブラウザで API Key の管理、アカウント情報の確認などが可能（[ham.nowcent.cn/console](https://ham.nowcent.cn/console)）
 - **QR コードログイン** — ユーザーは Web 上で QR コードをスキャンしてログインできます
 - **Passkey ログイン** — WebAuthn / Passkey パスワードレスログインをサポート
 - **モバイル H5 フォールバック** — Ham ネイティブアプリがインストールされていない場合、Web ベースのインストール案内と Passkey ログインオプションを提供
@@ -68,7 +68,7 @@ app/                # Next.js App Router エントリー
     auth/           # 認証関連 API（ログイン、ログアウト、リフレッシュ、Passkey、QR コード）
     sso/            # SSO 関連 API（同意確認、同意情報）
   sso-authorize/    # SSO 認証ページ（ログインビュー、QR ログイン、Passkey ログイン）
-  console/          # Web コンソール（Token 管理、アカウント情報）
+console/          # Web コンソール（API Key 管理、アカウント情報）
 components/         # 共有 UI コンポーネント
   LanguageSwitcher  # 言語切り替え
   ThemeSwitcher     # テーマ切り替え

--- a/docs/src/ja/developers/ham-web/index.md
+++ b/docs/src/ja/developers/ham-web/index.md
@@ -68,7 +68,7 @@ app/                # Next.js App Router エントリー
     auth/           # 認証関連 API（ログイン、ログアウト、リフレッシュ、Passkey、QR コード）
     sso/            # SSO 関連 API（同意確認、同意情報）
   sso-authorize/    # SSO 認証ページ（ログインビュー、QR ログイン、Passkey ログイン）
-console/          # Web コンソール（API Key 管理、アカウント情報）
+  console/          # Web コンソール（API Key 管理、アカウント情報）
 components/         # 共有 UI コンポーネント
   LanguageSwitcher  # 言語切り替え
   ThemeSwitcher     # テーマ切り替え

--- a/docs/src/ja/guide/mcp/config.md
+++ b/docs/src/ja/guide/mcp/config.md
@@ -1,5 +1,5 @@
 ---
-description: "Ham MCPサービス設定ガイド — Claude Desktop、CursorなどのクライアントでHam MCPを設定。"
+description: "Ham MCPサービス設定ガイド — Claude、ChatGPT、Cherry Studio、Cursor、Antigravity、Claude Code、Codexなどのクライアントで Ham MCP を設定。"
 prev:
   text: 'MCP紹介'
   link: '/ja/guide/mcp/'
@@ -15,16 +15,31 @@ prev:
 | --- | --- |
 | トランスポート | Streamable HTTP |
 | サービスURL | `https://mcp.ham.nowcent.cn/mcp` |
-| 認証方式 | Bearer Token |
+| 認証方式 | OAuth動的登録（推奨） / API Key |
 
-## Claude Desktop
+::: tip
+OAuth動的登録に対応したクライアントでは、サービスURLを入力するだけで残りの手順が自動で完了します。詳細は [MCP紹介 - OAuth動的登録](/ja/guide/mcp/#oauth動的登録推奨) を参照してください。
+:::
 
-Claude Desktopの設定ファイルを編集します：
+## デスクトップアプリ
+
+### [Claude](https://claude.ai/)
+
+#### 方法1：OAuth動的登録（推奨）
+
+1. Claude を開き、**Settings → Connectors** に進む
+2. **Add custom connector** をクリック
+3. 入力：
+   - **Name**: `Ham`
+   - **Remote MCP server URL**: `https://mcp.ham.nowcent.cn/mcp`
+4. **Connect** をクリックすると、ブラウザで Ham 認可ページが開きます。ログイン後に同意するだけで利用開始できます。
+
+#### 方法2：API Key（デスクトップ版のみ）
+
+デスクトップ版では設定ファイルを編集してAPI Keyを利用できます：
 
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-
-次の設定を追加します：
 
 ```json
 {
@@ -33,33 +48,272 @@ Claude Desktopの設定ファイルを編集します：
       "type": "streamable-http",
       "url": "https://mcp.ham.nowcent.cn/mcp",
       "headers": {
-        "Authorization": "Bearer <YOUR_TOKEN>"
+        "Authorization": "Bearer <YOUR_API_KEY>"
       }
     }
   }
 }
 ```
 
-`<YOUR_TOKEN>` を [Hamコンソール](https://ham.nowcent.cn/console/tokens)で生成したTokenに置き換えてください。
+`<YOUR_API_KEY>` を [Hamコンソール](https://ham.nowcent.cn/console/tokens) で生成したAPI Keyに置き換え、保存後に Claude を再起動してください。
 
-保存後、Claude Desktopを再起動すると変更が反映されます。
+### [ChatGPT](https://chatgpt.com/)
 
-## Cursor
+1. ChatGPT を開き、**Settings → Connectors → Advanced** に進む
+2. **Developer mode**（開発者モード）を有効にする
+3. Connectors ページに戻り、**Create** をクリック
+4. 入力：
+   - **Name**: `Ham`
+   - **MCP Server URL**: `https://mcp.ham.nowcent.cn/mcp`
+   - **Authentication**: `OAuth`
+5. **Create** をクリックすると Ham 認可ページに遷移し、許可するとチャット内で利用できます。
 
-CursorでMCPサービスを設定するには：
+::: tip
+ChatGPT の Connectors 機能は現在、ChatGPT Plus / Pro / Business / Enterprise ユーザーのみ利用可能です。
+:::
+
+### [Cherry Studio](https://cherry-ai.com/)
+
+1. Cherry Studio を開き、**設定 → MCPサーバー → サーバーを追加** に進む
+2. 入力：
+   - **名前**: `Ham`
+   - **タイプ**: `Streamable HTTP`
+   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
+3. 保存して有効化します。最初のツール呼び出しでブラウザが起動し、OAuth フローが完了します。
+4. API Key を使う場合は **Headers** に追加：
+   ```
+   Authorization=Bearer <YOUR_API_KEY>
+   ```
+
+### [WorkBuddy](https://www.codebuddy.cn/work/)
+
+1. WorkBuddy を開き、**設定 → MCP マーケットプレイス → カスタム MCP** に進む
+2. **MCP サーバーを追加** を選択し、次を入力：
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+3. 保存するとブラウザが起動して OAuth フローが完了します。API Key を使う場合は `headers.Authorization` を追加：
+   ```json
+   "headers": {
+     "Authorization": "Bearer <YOUR_API_KEY>"
+   }
+   ```
+
+## IDE / エディタ
+
+### [Cursor](https://cursor.com/)
+
+#### 方法1：OAuth動的登録（推奨）
 
 1. Cursor設定を開く（`Cmd + ,`）
-2. **MCP** セクションに移動
-3. **Add new MCP server** をクリック
-4. 設定を入力：
-   - **Name**: `Ham`
-   - **Type**: `streamable-http`
-   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
-5. Headersに認証情報を追加：
-   - **Key**: `Authorization`
-   - **Value**: `Bearer <YOUR_TOKEN>`
+2. **MCP & Integrations** に進み、**New MCP Server** をクリック
+3. 設定を入力：
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+4. 保存すると Cursor がブラウザを起動して OAuth フローを完了させます。
 
-`<YOUR_TOKEN>` を実際のTokenに置き換えてください。
+#### 方法2：API Key
+
+設定に `headers` フィールドを追加します：
+
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "type": "streamable-http",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### [Antigravity](https://antigravity.google/)
+
+1. Antigravity を開き、**Settings → MCP Servers** に進む
+2. **Add custom MCP server** をクリックして入力：
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+3. 保存するとブラウザで Ham 認可ページが開き、OAuth フローが完了します。
+4. API Key を使う場合は `headers.Authorization` を追加するだけです。
+
+### [CodeBuddy](https://copilot.tencent.com/)
+
+1. CodeBuddy パネルを開き、**設定 → MCP マーケットプレイス → カスタム MCP** に進む
+2. **MCP サーバーを追加** を選択し、次を入力：
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
+3. 保存するとブラウザが起動して OAuth フローが完了します。API Key を使う場合は `headers.Authorization` を追加してください：
+   ```json
+   "headers": {
+     "Authorization": "Bearer <YOUR_API_KEY>"
+   }
+   ```
+
+## コマンドラインツール
+
+### [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+
+ターミナルで次のコマンドを実行して Ham MCP サービスを追加します（OAuth動的登録が自動で適用されます）：
+
+```bash
+claude mcp add --transport http ham https://mcp.ham.nowcent.cn/mcp
+```
+
+初回利用時にブラウザで認可フローが開きます。API Keyを使う場合：
+
+```bash
+claude mcp add --transport http ham https://mcp.ham.nowcent.cn/mcp \
+  --header "Authorization: Bearer <YOUR_API_KEY>"
+```
+
+### [Codex](https://github.com/openai/codex)
+
+`~/.codex/config.toml` で MCP サービスを設定します。
+
+#### 方法1：OAuth動的登録（推奨）
+
+```toml
+[mcp_servers.ham]
+url = "https://mcp.ham.nowcent.cn/mcp"
+```
+
+`codex` を初めて起動するとブラウザで認可フローが開きます。
+
+#### 方法2：API Key
+
+```toml
+[mcp_servers.ham]
+url = "https://mcp.ham.nowcent.cn/mcp"
+
+[mcp_servers.ham.headers]
+Authorization = "Bearer <YOUR_API_KEY>"
+```
+
+### [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+
+`~/.gemini/settings.json`（ユーザーレベル）またはプロジェクトルートの `.gemini/settings.json`（プロジェクトレベル）で MCP サービスを設定します。
+
+#### 方法1：OAuth動的登録（推奨）
+
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "httpUrl": "https://mcp.ham.nowcent.cn/mcp"
+    }
+  }
+}
+```
+
+最初のツール呼び出し時にブラウザで認可フローが開きます。
+
+#### 方法2：API Key
+
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "httpUrl": "https://mcp.ham.nowcent.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### [OpenCode](https://opencode.ai/)
+
+プロジェクトルートまたは `~/.config/opencode/opencode.json` で MCP サービスを設定します。
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "ham": {
+      "type": "remote",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+`opencode` を初めて起動するとブラウザで認可フローが開きます。API Key を使う場合：
+
+```json
+{
+  "mcp": {
+    "ham": {
+      "type": "remote",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "enabled": true,
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### [OpenClaw](https://openclaw.ai/)
+
+#### 方法1：対話で追加（推奨）
+
+OpenClaw のチャットで次のように伝えるだけです：
+
+```
+streamable HTTP トランスポートと OAuth 動的登録を使って、URL https://mcp.ham.nowcent.cn/mcp の MCP サーバーを「ham」という名前で追加してください。
+```
+
+OpenClaw が自動的に設定を書き込み、ブラウザで OAuth フローを開きます。
+
+#### 方法2：CLI コマンド
+
+```bash
+openclaw mcp add ham --transport http --url https://mcp.ham.nowcent.cn/mcp
+```
+
+API Key を使う場合：
+
+```bash
+openclaw mcp add ham --transport http --url https://mcp.ham.nowcent.cn/mcp \
+  --header "Authorization: Bearer <YOUR_API_KEY>"
+```
 
 ## その他のMCPクライアント
 
@@ -67,27 +321,6 @@ CursorでMCPサービスを設定するには：
 
 1. **Streamable HTTP** トランスポートを選択
 2. サービスURLを `https://mcp.ham.nowcent.cn/mcp` に設定
-3. リクエストヘッダーに `Authorization: Bearer <YOUR_TOKEN>` を追加
+3. クライアント標準のOAuthフローを優先利用。非対応の場合はリクエストヘッダーに `Authorization: Bearer <YOUR_API_KEY>` を追加
 
 具体的な設定方法は、お使いのクライアントのドキュメントを参照してください。
-
-## トラブルシューティング
-
-### 接続に失敗する場合
-
-- サービスURLが正しいことを確認：`https://mcp.ham.nowcent.cn/mcp`
-- ネットワーク接続を確認
-- クライアントがStreamable HTTPトランスポートに対応していることを確認
-
-### 認証に失敗する場合
-
-- Tokenが正しいことを確認（`Bearer` プレフィックスを含む）
-- Tokenの有効期限を [Hamコンソール](https://ham.nowcent.cn/console/tokens) で確認
-- Tokenが漏洩した場合は、コンソールですぐに削除して新しいTokenを生成
-
-### Tokenのセキュリティ
-
-- Tokenをコードリポジトリにコミットしない
-- 公開場所でTokenを共有しない
-- 定期的にTokenをローテーションする
-- 管理しやすいよう、クライアントごとに個別のTokenを作成する

--- a/docs/src/ja/guide/mcp/config.md
+++ b/docs/src/ja/guide/mcp/config.md
@@ -87,8 +87,8 @@ ChatGPT の Connectors 機能は現在、ChatGPT Plus / Pro / Business / Enterpr
 
 ### [WorkBuddy](https://www.codebuddy.cn/work/)
 
-1. WorkBuddy を開き、**設定 → MCP マーケットプレイス → カスタム MCP** に進む
-2. **MCP サーバーを追加** を選択し、次を入力：
+1. WorkBuddy を開き、**コネクタ → カスタムコネクタ → MCP を設定** に進む
+2. 次の設定を入力：
    ```json
    {
      "mcpServers": {
@@ -112,22 +112,37 @@ ChatGPT の Connectors 機能は現在、ChatGPT Plus / Pro / Business / Enterpr
 
 #### 方法1：OAuth動的登録（推奨）
 
-1. Cursor 設定を開き（`Cmd + ,`）、**MCP & Integrations** に進む
-2. **New MCP Server** をクリックし、ダイアログに入力：
-   - **Name**: `ham`
-   - **Type**: `SSE`
-   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
+1. Cursor 設定を開き（`Cmd + ,`）、**Tools & MCPs** に進む
+2. **New MCP Server** をクリックすると、Cursor が新しいウィンドウ（`mcp.json`）を開いて設定を貼り付けられます。次の内容を貼り付けてください：
+   ```json
+   {
+     "mcpServers": {
+       "ham": {
+         "type": "streamable-http",
+         "url": "https://mcp.ham.nowcent.cn/mcp"
+       }
+     }
+   }
+   ```
 3. 保存すると Cursor がブラウザを起動して OAuth フローを完了させます。
 
 #### 方法2：API Key
 
-**New MCP Server** ダイアログで上記の Name / Type / URL を入力し、**Headers** セクションに次の行を追加します：
+設定に `headers.Authorization` を追加します：
 
-| Key | Value |
-| --- | --- |
-| `Authorization` | `Bearer <YOUR_API_KEY>` |
-
-保存すると利用できます。
+```json
+{
+  "mcpServers": {
+    "ham": {
+      "type": "streamable-http",
+      "url": "https://mcp.ham.nowcent.cn/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
 
 ### [Antigravity](https://antigravity.google/)
 

--- a/docs/src/ja/guide/mcp/config.md
+++ b/docs/src/ja/guide/mcp/config.md
@@ -112,38 +112,22 @@ ChatGPT の Connectors 機能は現在、ChatGPT Plus / Pro / Business / Enterpr
 
 #### 方法1：OAuth動的登録（推奨）
 
-1. Cursor設定を開く（`Cmd + ,`）
-2. **MCP & Integrations** に進み、**New MCP Server** をクリック
-3. 設定を入力：
-   ```json
-   {
-     "mcpServers": {
-       "ham": {
-         "type": "streamable-http",
-         "url": "https://mcp.ham.nowcent.cn/mcp"
-       }
-     }
-   }
-   ```
-4. 保存すると Cursor がブラウザを起動して OAuth フローを完了させます。
+1. Cursor 設定を開き（`Cmd + ,`）、**MCP & Integrations** に進む
+2. **New MCP Server** をクリックし、ダイアログに入力：
+   - **Name**: `ham`
+   - **Type**: `SSE`
+   - **URL**: `https://mcp.ham.nowcent.cn/mcp`
+3. 保存すると Cursor がブラウザを起動して OAuth フローを完了させます。
 
 #### 方法2：API Key
 
-設定に `headers` フィールドを追加します：
+**New MCP Server** ダイアログで上記の Name / Type / URL を入力し、**Headers** セクションに次の行を追加します：
 
-```json
-{
-  "mcpServers": {
-    "ham": {
-      "type": "streamable-http",
-      "url": "https://mcp.ham.nowcent.cn/mcp",
-      "headers": {
-        "Authorization": "Bearer <YOUR_API_KEY>"
-      }
-    }
-  }
-}
-```
+| Key | Value |
+| --- | --- |
+| `Authorization` | `Bearer <YOUR_API_KEY>` |
+
+保存すると利用できます。
 
 ### [Antigravity](https://antigravity.google/)
 

--- a/docs/src/ja/guide/mcp/index.md
+++ b/docs/src/ja/guide/mcp/index.md
@@ -26,21 +26,38 @@ https://mcp.ham.nowcent.cn/mcp
 
 ## 認証
 
-Ham MCPサービスは **Bearer Token** 認証を使用します。HamコンソールでTokenを生成し、MCPクライアントの設定で使用する必要があります。
+Ham MCPサービスは2種類の認証方式をサポートします：
 
-### Tokenの取得
+- **OAuth動的登録（推奨）**：クライアントが初回接続時に登録と認可を自動で完了します。API Keyを手動で発行する必要はなく、MCPのOAuthに対応した最新クライアント（Claude Desktop、Cursor、ChatGPT、Codexなど）に最適です。
+- **API Key**：HamコンソールでAPI Keyを手動生成し、`Authorization: Bearer <API_KEY>` リクエストヘッダーで認証する方式。OAuth動的登録に対応していないクライアントや、長期固定の認証情報が必要な場合に利用します。
 
-1. [Hamコンソール - Token管理](https://ham.nowcent.cn/console/tokens)にアクセス
-2. 「Tokenを作成」をクリック
-3. Tokenに説明を追加（例：「Claude Desktop」）して管理しやすくする
-4. 生成されたTokenをコピー（**一度だけ表示されるので安全に保管してください**）
+### OAuth動的登録（推奨）
 
-::: warning
-Tokenを他人と共有しないでください。Tokenはアカウントの認証情報と同等であり、漏洩すると個人情報への不正アクセスされる可能性があります。
+Ham MCPサービスは [MCP Authorization 仕様](https://modelcontextprotocol.io/specification/draft/basic/authorization) に準拠し、[OAuth 2.0 動的クライアント登録（RFC 7591）](https://datatracker.ietf.org/doc/html/rfc7591) と [Protected Resource Metadata（RFC 9728）](https://datatracker.ietf.org/doc/html/rfc9728) を実装しています。
+
+接続フローはクライアントが自動で処理します：
+
+1. クライアントがサービスURLへアクセスし、`401 Unauthorized` を受け取る
+2. `/.well-known/oauth-protected-resource` から認可サーバーをディスカバリ
+3. 動的登録エンドポイントへ自動登録し、`client_id` を取得
+4. ブラウザが Ham 認可ページに遷移、ログインと同意の後にクライアントへ戻る
+5. クライアントがアクセストークンを取得し、以降のリクエストへ自動付与（手動設定不要）
+
+::: tip
+動的登録を利用する場合、クライアントにサービスURL `https://mcp.ham.nowcent.cn/mcp` を入力するだけで、それ以外の手順は自動で完了します。
 :::
 
-## 次のステップ
+### API Key
 
-各MCPクライアントでHam MCPサービスを設定する方法：
+クライアントがOAuth動的登録に非対応の場合や、長期固定の認証情報を使用したい場合は、HamコンソールでAPI Keyを生成して手動で設定します。
 
-[設定ガイド →](/ja/guide/mcp/config)
+#### API Keyの取得
+
+1. [Hamコンソール - API Keys](https://ham.nowcent.cn/console/tokens)にアクセス
+2. 「API Keyを作成」をクリック
+3. API Keyに説明を追加（例：「Claude Desktop」）して管理しやすくする
+4. 生成されたAPI Keyをコピー（**一度だけ表示されるので安全に保管してください**）
+
+::: warning
+API Keyを他人と共有しないでください。API Keyはアカウントの認証情報と同等であり、漏洩すると個人情報への不正アクセスされる可能性があります。
+:::


### PR DESCRIPTION
## Summary

Expand the MCP documentation with the OAuth dynamic registration flow and add per-client configuration guides across all locales (zh / en / ja).

## Changes

### MCP intro page (`guide/mcp/index.md`)
- Document **OAuth dynamic registration** as the recommended auth method
- Keep API Key as a fallback option
- Rename **Ham Token** → **Ham API Key(s)** consistently

### MCP config page (`guide/mcp/config.md`)
- Add per-client tutorials, grouped into three categories:
  - **Desktop clients**: Claude, ChatGPT, Cherry Studio, WorkBuddy
  - **IDEs & editors**: Cursor, Antigravity, CodeBuddy
  - **CLI tools**: Claude Code, Codex, Gemini CLI, OpenCode, OpenClaw
- Each client links to its official site / repository
- Each client documents OAuth (preferred) and/or API Key paths
- Section headings aligned with the sidebar TOC

### i18n
- Synchronized changes across `docs/src/`, `docs/src/en/`, `docs/src/ja/`

## Files
- `docs/src/{,, en/, ja/}guide/mcp/index.md`
- `docs/src/{,, en/, ja/}guide/mcp/config.md`
- `docs/src/{,, en/, ja/}developers/ham-web/index.md` (Ham API Key rename)
