### PR TITLE
ci: build Android releases on GitHub runners

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,305 @@
+name: Android Release Build
+
+on:
+  repository_dispatch:
+    types: [android-release-requested]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      public_tag: ${{ steps.public-release.outputs.public_tag }}
+
+    steps:
+      - name: Checkout documentation repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Checkout Android repository
+        uses: actions/checkout@v5
+        with:
+          repository: whu-ham/ham-android
+          ref: ${{ github.event.client_payload.source_ref }}
+          path: ham-android
+          token: ${{ secrets.HAM_ANDROID_REPO_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure private proto repository access
+        env:
+          PROTO_REPO_TOKEN: ${{ secrets.PROTO_REPO_TOKEN }}
+        run: |
+          if [ -z "$PROTO_REPO_TOKEN" ]; then
+            echo "::error::PROTO_REPO_TOKEN is required to clone whu-ham/ham-proto"
+            exit 1
+          fi
+          PROTO_GIT_CONFIG="$RUNNER_TEMP/ham-proto-gitconfig"
+          git config --file "$PROTO_GIT_CONFIG" url."https://x-access-token:${PROTO_REPO_TOKEN}@github.com/whu-ham/".insteadOf "https://github.com/whu-ham/"
+          echo "GIT_CONFIG_GLOBAL=$PROTO_GIT_CONFIG" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10.6.4
+          run_install: false
+          dest: ${{ runner.temp }}/setup-pnpm-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ham-android/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: ham-android
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
+          gradle-home-cache-cleanup: true
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Android NDK and Rust
+        run: |
+          sdkmanager "ndk;27.2.12479018"
+          echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/27.2.12479018" >> "$GITHUB_ENV"
+          rustup toolchain install stable --profile minimal
+          rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android
+          cargo install cargo-ndk --locked
+
+      - name: Update version files
+        working-directory: ham-android
+        env:
+          VERSION_CODE: ${{ github.event.client_payload.version_code }}
+          VERSION_NAME: ${{ github.event.client_payload.version_name }}
+        run: |
+          echo -n "$VERSION_CODE" > android/metadata/versionCode
+          echo -n "$VERSION_NAME" > android/metadata/versionName
+
+      - name: Restore keystore
+        shell: bash
+        run: |
+          set -euo pipefail
+          KEYSTORE_PATH="$RUNNER_TEMP/ham.jks"
+          echo "$HAM_KEYSTORE_B64" | base64 -d > "$KEYSTORE_PATH"
+          chmod 600 "$KEYSTORE_PATH"
+          echo "KEYSTORE_PATH=$KEYSTORE_PATH" >> "$GITHUB_ENV"
+        env:
+          HAM_KEYSTORE_B64: ${{ secrets.HAM_KEYSTORE_B64 }}
+
+      - name: Setup GOOGLE_AUTH key
+        run: |
+          set -euo pipefail
+          KEY_PATH="$RUNNER_TEMP/keys.json"
+          echo "$GOOGLE_AUTH" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          echo "SUPPLY_JSON_KEY=$KEY_PATH" >> "$GITHUB_ENV"
+        env:
+          GOOGLE_AUTH: ${{ secrets.GOOGLE_AUTH }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: ham-android/android
+
+      - name: Build Beta
+        if: ${{ github.event.client_payload.build_type == 'beta' }}
+        run: |
+          cd ham-android/android
+          bundle exec fastlane android beta
+        env:
+          ORG_GRADLE_PROJECT_ham.key.password: ${{ secrets.HAM_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_ham.key.alias: ${{ secrets.HAM_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_versionType: beta
+
+      - name: Build Release
+        if: ${{ github.event.client_payload.build_type == 'release' }}
+        run: |
+          cd ham-android/android
+          bundle exec fastlane android release
+        env:
+          ORG_GRADLE_PROJECT_ham.key.password: ${{ secrets.HAM_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_ham.key.alias: ${{ secrets.HAM_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_versionType: release
+
+      - name: Upload APKs
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apks
+          path: ham-android/android/app/build/outputs/apk/**/*.apk
+          retention-days: 1
+
+      - name: Download APKs
+        uses: actions/download-artifact@v4
+        with:
+          name: release-apks
+          path: apks
+
+      - name: Generate release notes
+        id: release-notes
+        env:
+          BUILD_TYPE: ${{ github.event.client_payload.build_type }}
+          VERSION_CODE: ${{ github.event.client_payload.version_code }}
+          VERSION_NAME: ${{ github.event.client_payload.version_name }}
+        run: |
+          VERSION_NAME="$VERSION_NAME"
+          VERSION_CODE="$VERSION_CODE"
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          echo "RELEASE_NOTES_FILE=$NOTES_FILE" >> "$GITHUB_ENV"
+
+          if [ "$BUILD_TYPE" = "beta" ]; then
+            PREVIOUS_TAG=$(git -C ham-android tag --list 'v*-beta' --sort=-version:refname | head -n 1 || true)
+            TITLE="## 🚀 Beta - ${VERSION_NAME} (${VERSION_CODE})"
+            BUILD_NOTE="> 此版本由 \`master\` 分支自动构建。"
+            IMPORTANT_NOTE_1="- 这是自动生成的 Beta 构建，不建议在生产环境使用。"
+            IMPORTANT_NOTE_2="- 已上传到 Google Play 内部测试。"
+            IMPORTANT_NOTE_3="- Beta 版本可能包含不稳定或未完成的变更，请谨慎使用。"
+          else
+            PREVIOUS_TAG=$(git -C ham-android tag --list 'v*' --sort=-version:refname | grep -Ev -- '-beta$' | head -n 1 || true)
+            TITLE="## 🎉 Release - ${VERSION_NAME} (${VERSION_CODE})"
+            BUILD_NOTE="> 此版本由 \`master\` 分支自动构建。"
+            IMPORTANT_NOTE_1="- 已上传到 Google Play 内部测试。"
+            IMPORTANT_NOTE_2="- 请从下方附件中下载合适的 APK 安装包。"
+            IMPORTANT_NOTE_3=""
+          fi
+
+          COMMITS=""
+          if [ -n "$PREVIOUS_TAG" ]; then
+            COMMITS=$(git -C ham-android log "${PREVIOUS_TAG}..${{ github.event.client_payload.source_ref }}" --no-merges --pretty=format:'- `%h` %s (%an)' | grep -Fv 'chore: bump version to ' || true)
+          fi
+          COMMIT_COUNT=$(printf '%s\n' "$COMMITS" | sed '/^$/d' | wc -l | tr -d ' ')
+
+          {
+            echo "$TITLE"
+            echo
+            echo "$BUILD_NOTE"
+            echo
+            echo "### 📝 更新日志"
+            echo
+            echo "待更新"
+            echo
+            echo "### 🔍 提交信息"
+            echo
+            if [ -n "$PREVIOUS_TAG" ]; then
+              echo "- 基于 \`${PREVIOUS_TAG}\` 之后的变更"
+              echo "- 提交数量：${COMMIT_COUNT}"
+              echo
+              if [ -n "$COMMITS" ]; then
+                echo "$COMMITS"
+              else
+                echo "- 该范围内没有匹配的提交。"
+              fi
+            else
+              echo "- 未找到符合条件的上一版本标签。"
+            fi
+            echo
+            echo "### ⚠️ 注意事项"
+            echo
+            echo "$IMPORTANT_NOTE_1"
+            echo "$IMPORTANT_NOTE_2"
+            if [ -n "$IMPORTANT_NOTE_3" ]; then
+              echo "$IMPORTANT_NOTE_3"
+            fi
+            echo
+            echo "### 📦 安装说明"
+            echo
+            echo "请从下方附件中下载合适的 APK 安装包。"
+            echo
+          } > "$NOTES_FILE"
+
+      - name: Determine public release tag
+        id: public-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_TYPE: ${{ github.event.client_payload.build_type }}
+          VERSION_NAME: ${{ github.event.client_payload.version_name }}
+        run: |
+          if [ "$BUILD_TYPE" = "release" ]; then
+            PUBLIC_TAG="v${VERSION_NAME}"
+            BETA_NUM=""
+          else
+            EXISTING_TAGS=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags" --paginate --jq '.[].ref' 2>/dev/null || echo "")
+            MAX_BETA=0
+            for REF in $EXISTING_TAGS; do
+              case "$REF" in
+                refs/tags/v${VERSION_NAME}-beta*)
+                  NUM="${REF##*-beta}"
+                  if [ "$NUM" -gt "$MAX_BETA" ] 2>/dev/null; then
+                    MAX_BETA="$NUM"
+                  fi
+                  ;;
+              esac
+            done
+            BETA_NUM=$((MAX_BETA + 1))
+            PUBLIC_TAG="v${VERSION_NAME}-beta${BETA_NUM}"
+          fi
+          echo "public_tag=$PUBLIC_TAG" >> "$GITHUB_OUTPUT"
+          echo "beta_num=$BETA_NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_TYPE: ${{ github.event.client_payload.build_type }}
+          PUBLIC_TAG: ${{ steps.public-release.outputs.public_tag }}
+        run: |
+          RELEASE_ARGS=("$PUBLIC_TAG" --repo "$GITHUB_REPOSITORY" --title "$PUBLIC_TAG" --notes-file "$RELEASE_NOTES_FILE")
+          if [ "$BUILD_TYPE" = "beta" ]; then
+            RELEASE_ARGS+=(--draft --prerelease)
+          else
+            RELEASE_ARGS+=(--draft)
+          fi
+          GITHUB_APKS=$(find apks -name '*Github*.apk' -type f)
+          if [ -z "$GITHUB_APKS" ]; then
+            echo "No Github APKs found"
+            exit 1
+          fi
+          gh release create "${RELEASE_ARGS[@]}" $GITHUB_APKS
+
+      - name: Notify Android repository
+        env:
+          GH_TOKEN: ${{ secrets.HAM_ANDROID_DISPATCH_TOKEN }}
+          REQUEST_ID: ${{ github.event.client_payload.request_id }}
+          BUILD_TYPE: ${{ github.event.client_payload.build_type }}
+          VERSION_CODE: ${{ github.event.client_payload.version_code }}
+          VERSION_NAME: ${{ github.event.client_payload.version_name }}
+          SOURCE_REF: ${{ github.event.client_payload.source_ref }}
+          PUBLIC_TAG: ${{ steps.public-release.outputs.public_tag }}
+          BETA_NUM: ${{ steps.public-release.outputs.beta_num }}
+        run: |
+          gh api repos/whu-ham/ham-android/dispatches --method POST --input - <<JSON
+          {
+            "event_type": "android-release-completed",
+            "client_payload": {
+              "request_id": "${REQUEST_ID}",
+              "build_type": "${BUILD_TYPE}",
+              "version_code": "${VERSION_CODE}",
+              "version_name": "${VERSION_NAME}",
+              "source_ref": "${SOURCE_REF}",
+              "public_tag": "${PUBLIC_TAG}",
+              "beta_num": "${BETA_NUM}"
+            }
+          }
+          JSON
+
+      - name: Cleanup credentials
+        if: always()
+        run: |
+          rm -f "$RUNNER_TEMP/keys.json" "$RUNNER_TEMP/ham.jks"
+          if [ -n "${GIT_CONFIG_GLOBAL:-}" ]; then
+            rm -f "$GIT_CONFIG_GLOBAL"
+          fi

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [android-release-requested]
 
+concurrency:
+  group: android-release-${{ github.event.client_payload.version_name }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -229,11 +233,12 @@ jobs:
           BUILD_TYPE: ${{ github.event.client_payload.build_type }}
           VERSION_NAME: ${{ github.event.client_payload.version_name }}
         run: |
+          set -euo pipefail
           if [ "$BUILD_TYPE" = "release" ]; then
             PUBLIC_TAG="v${VERSION_NAME}"
             BETA_NUM=""
           else
-            EXISTING_TAGS=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags" --paginate --jq '.[].ref' 2>/dev/null || echo "")
+            EXISTING_TAGS=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags" --paginate --jq '.[].ref')
             MAX_BETA=0
             for REF in $EXISTING_TAGS; do
               case "$REF" in


### PR DESCRIPTION
## Summary\n- build ham-android beta/release packages on the official ubuntu-latest runner\n- preserve the existing Fastlane build, APK, release notes, and public tag behavior\n- callback ham-android only after the GitHub Release is created\n\n## Validation\n- YAML parsing passed\n- git diff --check passed\n\nRequires the documented Android build and dispatch secrets.