### PR TITLE
fix(ci): align Android release pnpm version

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.2.0
         with:
-          version: 10.6.4
+          version: 11.1.3
           run_install: false
           dest: ${{ runner.temp }}/setup-pnpm-${{ github.run_id }}-${{ github.run_attempt }}
 


### PR DESCRIPTION
## Summary
- align the Android release workflow with the repository's pnpm 11.1.3 declaration
- prevent pnpm/action-setup from failing on conflicting versions

## Validation
- git diff --check
- verified package.json declares pnpm@11.1.3