### PR TITLE
fix(ci): scope pnpm setup to Android checkout

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.2.0
         with:
-          version: 11.1.3
+          version: 10.6.4
+          package_json_file: ham-android/package.json
           run_install: false
           dest: ${{ runner.temp }}/setup-pnpm-${{ github.run_id }}-${{ github.run_attempt }}
 


### PR DESCRIPTION
## Summary
- make pnpm/action-setup inspect ham-android/package.json rather than the documentation site's package.json
- retain pnpm 10.6.4, matching the existing successful ham-android build workflow
- avoid changing pnpm's dependency layout for the delegated release build

## Validation
- git diff --check
- confirmed the existing ham-android build workflow uses pnpm 10.6.4