### PR TITLE
ci: publish Android betas directly and add iOS TestFlight workflow

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -84,16 +84,6 @@ jobs:
         env:
           HAM_KEYSTORE_B64: ${{ secrets.HAM_KEYSTORE_B64 }}
 
-      - name: Setup GOOGLE_AUTH key
-        run: |
-          set -euo pipefail
-          KEY_PATH="$RUNNER_TEMP/keys.json"
-          echo "$GOOGLE_AUTH" > "$KEY_PATH"
-          chmod 600 "$KEY_PATH"
-          echo "SUPPLY_JSON_KEY=$KEY_PATH" >> "$GITHUB_ENV"
-        env:
-          GOOGLE_AUTH: ${{ secrets.GOOGLE_AUTH }}
-
       - name: Setup Ruby
         working-directory: android
         shell: bash
@@ -150,7 +140,7 @@ jobs:
         if: ${{ inputs.build_type == 'beta' }}
         run: |
           cd android
-          bundle exec fastlane android beta
+          bundle exec fastlane android build
         env:
           ORG_GRADLE_PROJECT_ham.key.password: ${{ secrets.HAM_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_ham.key.alias: ${{ secrets.HAM_KEY_ALIAS }}
@@ -159,7 +149,7 @@ jobs:
       - name: Cleanup credentials
         if: always()
         run: |
-          rm -f "$RUNNER_TEMP/keys.json" "$RUNNER_TEMP/ham.jks"
+          rm -f "$RUNNER_TEMP/ham.jks"
           if [ -n "${GIT_CONFIG_GLOBAL:-}" ]; then
             rm -f "$GIT_CONFIG_GLOBAL"
           fi

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -212,14 +212,14 @@ jobs:
           if [ "$BUILD_TYPE" = "beta" ]; then
             PREVIOUS_TAG=$(git tag --list 'v*-beta' --sort=-version:refname | head -n 1 || true)
             TITLE="## 🚀 Beta - ${VERSION_NAME} (${VERSION_CODE})"
-            BUILD_NOTE="> 此版本由 \`master\` 分支自动构建。"
+            BUILD_NOTE="> 此版本由 \`main\` 分支自动构建。"
             IMPORTANT_NOTE_1="- 这是自动生成的 Beta 构建，不建议在生产环境使用。"
             IMPORTANT_NOTE_2="- 已上传到 Google Play 内部测试。"
             IMPORTANT_NOTE_3="- Beta 版本可能包含不稳定或未完成的变更，请谨慎使用。"
           else
             PREVIOUS_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -Ev -- '-beta$' | head -n 1 || true)
             TITLE="## 🎉 Release - ${VERSION_NAME} (${VERSION_CODE})"
-            BUILD_NOTE="> 此版本由 \`master\` 分支自动构建。"
+            BUILD_NOTE="> 此版本由 \`main\` 分支自动构建。"
             IMPORTANT_NOTE_1="- 已上传到 Google Play 内部测试。"
             IMPORTANT_NOTE_2="- 请从下方附件中下载合适的 APK 安装包。"
             IMPORTANT_NOTE_3=""
@@ -263,10 +263,6 @@ jobs:
               echo "$IMPORTANT_NOTE_3"
             fi
             echo
-            echo "### 📦 安装说明"
-            echo
-            echo "请从下方附件中下载合适的 APK 安装包。"
-            echo
           } > "$NOTES_FILE"
 
       - name: Determine public release tag
@@ -307,7 +303,7 @@ jobs:
         run: |
           RELEASE_ARGS=("$PUBLIC_TAG" --repo "$GITHUB_REPOSITORY" --title "$PUBLIC_TAG" --notes-file "$RELEASE_NOTES_FILE")
           if [ "$BUILD_TYPE" = "beta" ]; then
-            RELEASE_ARGS+=(--draft --prerelease)
+            RELEASE_ARGS+=(--prerelease)
           else
             RELEASE_ARGS+=(--draft)
           fi

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,132 @@
+name: iOS Manual Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: iOS branch to build
+        required: true
+        type: string
+        default: main
+
+jobs:
+  build:
+    runs-on: macos-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout iOS repository
+        uses: actions/checkout@v5
+        with:
+          repository: whu-ham/ham-ios
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.HAM_IOS_REPO_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure private proto repository access
+        env:
+          PROTO_REPO_TOKEN: ${{ secrets.PROTO_REPO_TOKEN }}
+        run: |
+          if [ -z "$PROTO_REPO_TOKEN" ]; then
+            echo "::error::PROTO_REPO_TOKEN is required to clone whu-ham/ham-proto"
+            exit 1
+          fi
+          PROTO_GIT_CONFIG="$RUNNER_TEMP/ham-proto-gitconfig"
+          git config --file "$PROTO_GIT_CONFIG" url."https://x-access-token:${PROTO_REPO_TOKEN}@github.com/whu-ham/ham-proto.git".insteadOf "https://github.com/whu-ham/ham-proto.git"
+          echo "GIT_CONFIG_GLOBAL=$PROTO_GIT_CONFIG" >> "$GITHUB_ENV"
+
+      - name: Setup Ruby
+        run: |
+          brew install ruby
+          echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
+          echo "$(gem environment gemdir)/bin" >> $GITHUB_PATH
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10.6.4
+          run_install: true
+
+      - name: Bundle Install
+        run: |
+          # 1) Read Bundler version from Gemfile.lock
+          BUNDLER_VERSION=$(ruby -e 'lock = File.read("Gemfile.lock"); puts lock[/BUNDLED WITH\n\s+([\d.]+)/, 1]')
+
+          # 2) Install the locked Bundler version to fix environment mismatch
+          gem install bundler -v "$BUNDLER_VERSION" --no-document
+
+          # 3) Run Bundler using an absolute path from RubyGems bindir (most reliable)
+          #    This ensures we call the executable from the active RubyGems environment.
+          "$(ruby -e 'print Gem.bindir')/bundle" install
+
+      - name: Setup App Store Connect API Key
+        env:
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/private_keys"
+          echo "$ASC_KEY_CONTENT" > "$RUNNER_TEMP/private_keys/AuthKey.p8"
+
+      - name: Create Keychain
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # Save original default keychain for later restoration
+          ORIGINAL_DEFAULT=$(security default-keychain -d user | xargs)
+          echo "ORIGINAL_DEFAULT_KEYCHAIN=$ORIGINAL_DEFAULT" >> $GITHUB_ENV
+          security delete-keychain build.keychain 2>/dev/null || true
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          security list-keychains -d user -s build.keychain $(security list-keychains -d user | sed s/\"//g)
+
+      - name: Install CocoaPods
+        run: gem install cocoapods --no-document
+
+      - name: CocoaPods Install
+        run: |
+          find ~/.cocoapods/repos -name "index.lock" -delete 2>/dev/null || true
+          cd Ham
+          pod install --repo-update
+
+      - name: Build IPA
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_PATH: ${{ runner.temp }}/private_keys/AuthKey.p8
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: bundle exec fastlane ios build
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-manual-build
+          path: fastlane/build/ham.ipa
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Cleanup Keychain
+        if: always()
+        run: |
+          security delete-keychain build.keychain 2>/dev/null || true
+          # Restore original default keychain
+          if [ -n "$ORIGINAL_DEFAULT_KEYCHAIN" ]; then
+            security default-keychain -s "$ORIGINAL_DEFAULT_KEYCHAIN" 2>/dev/null || true
+          else
+            security default-keychain -s ~/Library/Keychains/login.keychain-db 2>/dev/null || true
+          fi
+          rm -f "$RUNNER_TEMP/private_keys/AuthKey.p8"
+
+      - name: Cleanup proto git config
+        if: always()
+        run: |
+          if [ -n "${GIT_CONFIG_GLOBAL:-}" ]; then
+            rm -f "$GIT_CONFIG_GLOBAL"
+          fi

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -12,7 +12,9 @@ jobs:
   build:
     runs-on: macos-latest
     permissions:
-      contents: read
+      # Write is required to push the version bump and the beta metadata back
+      # to this repository.
+      contents: write
     outputs:
       version_name: ${{ steps.build.outputs.version_name }}
       version_code: ${{ steps.build.outputs.version_code }}
@@ -179,7 +181,7 @@ jobs:
           VERSION_NAME: ${{ steps.build.outputs.version_name }}
           VERSION_CODE: ${{ steps.build.outputs.version_code }}
           TESTFLIGHT_URL: ${{ vars.IOS_TESTFLIGHT_URL }}
-          DOCS_REPO_TOKEN: ${{ secrets.HAM_DOCS_REPO_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if [ -z "$TESTFLIGHT_URL" ]; then
@@ -196,7 +198,9 @@ jobs:
 
           # Checkout the docs site on a scratch path so the build workspace stays clean.
           DOCS_DIR="$RUNNER_TEMP/ham-docs"
-          git clone --depth 1 "https://x-access-token:${DOCS_REPO_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$DOCS_DIR"
+          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$DOCS_DIR"
+
+          mkdir -p "$DOCS_DIR/docs/src/public"
 
           # Build the JSON with jq so notes containing quotes or newlines stay valid.
           PUBLISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -1,0 +1,209 @@
+name: iOS Release Build
+
+on:
+  repository_dispatch:
+    types: [ios-release-requested]
+
+concurrency:
+  group: ios-release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: [self-hosted, macOS]
+    permissions:
+      contents: read
+    outputs:
+      version_name: ${{ steps.build.outputs.version_name }}
+      version_code: ${{ steps.build.outputs.version_code }}
+      tag: ${{ steps.build.outputs.tag }}
+      commit_sha: ${{ steps.bump.outputs.commit_sha }}
+
+    steps:
+      - name: Checkout iOS repository
+        uses: actions/checkout@v5
+        with:
+          repository: whu-ham/ham-ios
+          ref: ${{ github.event.client_payload.source_ref }}
+          token: ${{ secrets.HAM_IOS_REPO_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure private proto repository access
+        env:
+          PROTO_REPO_TOKEN: ${{ secrets.PROTO_REPO_TOKEN }}
+        run: |
+          if [ -z "$PROTO_REPO_TOKEN" ]; then
+            echo "::error::PROTO_REPO_TOKEN is required to clone whu-ham/ham-proto"
+            exit 1
+          fi
+          PROTO_GIT_CONFIG="$RUNNER_TEMP/ham-proto-gitconfig"
+          git config --file "$PROTO_GIT_CONFIG" url."https://x-access-token:${PROTO_REPO_TOKEN}@github.com/whu-ham/ham-proto.git".insteadOf "https://github.com/whu-ham/ham-proto.git"
+          echo "GIT_CONFIG_GLOBAL=$PROTO_GIT_CONFIG" >> "$GITHUB_ENV"
+
+      - name: Clean node_modules
+        run: rm -rf node_modules
+
+      - name: Setup Ruby
+        run: |
+          brew install ruby
+          echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
+          echo "$(gem environment gemdir)/bin" >> $GITHUB_PATH
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10.6.4
+          run_install: true
+
+      - name: Bundle Install
+        run: |
+          # 1) Read Bundler version from Gemfile.lock
+          BUNDLER_VERSION=$(ruby -e 'lock = File.read("Gemfile.lock"); puts lock[/BUNDLED WITH\n\s+([\d.]+)/, 1]')
+
+          # 2) Install the locked Bundler version to fix environment mismatch
+          gem install bundler -v "$BUNDLER_VERSION" --no-document
+
+          # 3) Run Bundler using an absolute path from RubyGems bindir (most reliable)
+          #    This ensures we call the executable from the active RubyGems environment.
+          "$(ruby -e 'print Gem.bindir')/bundle" install
+
+      - name: Setup App Store Connect API Key
+        env:
+          ASC_KEY_CONTENT: ${{ secrets.ASC_KEY_CONTENT }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/private_keys"
+          echo "$ASC_KEY_CONTENT" > "$RUNNER_TEMP/private_keys/AuthKey.p8"
+
+      - name: Create Keychain
+        env:
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # Save original default keychain for later restoration
+          ORIGINAL_DEFAULT=$(security default-keychain -d user | xargs)
+          echo "ORIGINAL_DEFAULT_KEYCHAIN=$ORIGINAL_DEFAULT" >> $GITHUB_ENV
+          security delete-keychain build.keychain 2>/dev/null || true
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          security list-keychains -d user -s build.keychain $(security list-keychains -d user | sed s/\"//g)
+
+      - name: Install CocoaPods
+        run: gem install cocoapods --no-document
+
+      - name: CocoaPods Install
+        run: |
+          find ~/.cocoapods/repos -name "index.lock" -delete 2>/dev/null || true
+          cd Ham
+          pod install --repo-update
+
+      - name: Build & Upload to TestFlight
+        id: build
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_PATH: ${{ runner.temp }}/private_keys/AuthKey.p8
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          VERSION_NUMBER: ${{ github.event.client_payload.version_number }}
+          BUILD_NUMBER: ${{ github.event.client_payload.build_number }}
+          PUBLIC_TESTING: ${{ github.event.client_payload.distribution == 'public' }}
+          EXTERNAL_TESTING_GROUP: ${{ github.event.client_payload.external_testing_group }}
+          CHANGELOG: ${{ github.event.client_payload.changelog }}
+        run: bundle exec fastlane ios beta
+
+      - name: Validate build outputs
+        env:
+          VERSION_NAME: ${{ steps.build.outputs.version_name }}
+          VERSION_CODE: ${{ steps.build.outputs.version_code }}
+          TAG: ${{ steps.build.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # `set -e` does not abort on a failing `[[ ]]`, so check each value explicitly.
+          [[ "$VERSION_NAME" =~ ^[0-9]+([.][0-9]+)*$ ]] || { echo "::error::Invalid version_name: $VERSION_NAME"; exit 1; }
+          [[ "$VERSION_CODE" =~ ^[0-9]+$ ]] || { echo "::error::Invalid version_code: $VERSION_CODE"; exit 1; }
+          [[ "$TAG" =~ ^v[0-9A-Za-z.+-]+$ ]] || { echo "::error::Invalid tag: $TAG"; exit 1; }
+
+      - name: Commit version bump
+        id: bump
+        env:
+          VERSION_NAME: ${{ steps.build.outputs.version_name }}
+          VERSION_CODE: ${{ steps.build.outputs.version_code }}
+          SOURCE_REF: ${{ github.event.client_payload.source_ref }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: bump version to ${VERSION_NAME} (${VERSION_CODE})"
+          fi
+
+          if ! git pull --rebase origin "$SOURCE_REF"; then
+            git rebase --abort
+            echo "::error::Rebase onto ${SOURCE_REF} failed. TestFlight already received ${VERSION_NAME} (${VERSION_CODE})."
+            exit 1
+          fi
+
+          git push origin "HEAD:${SOURCE_REF}"
+          COMMIT_SHA=$(git rev-parse HEAD)
+          [[ "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::Invalid commit sha: $COMMIT_SHA"; exit 1; }
+          echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+
+      - name: Notify iOS repository
+        env:
+          HAM_IOS_DISPATCH_TOKEN: ${{ secrets.HAM_IOS_DISPATCH_TOKEN }}
+          REQUEST_ID: ${{ github.event.client_payload.request_id }}
+          SOURCE_REF: ${{ github.event.client_payload.source_ref }}
+          VERSION_NAME: ${{ steps.build.outputs.version_name }}
+          VERSION_CODE: ${{ steps.build.outputs.version_code }}
+          TAG: ${{ steps.build.outputs.tag }}
+          COMMIT_SHA: ${{ steps.bump.outputs.commit_sha }}
+        run: |
+          # Use curl because the gh CLI is not guaranteed to exist on self-hosted macOS runners.
+          curl --fail-with-body -sS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${HAM_IOS_DISPATCH_TOKEN}" \
+            "https://api.github.com/repos/whu-ham/ham-ios/dispatches" \
+            --data-binary @- <<JSON
+          {"event_type":"ios-release-completed","client_payload":{"request_id":"${REQUEST_ID}","source_ref":"${SOURCE_REF}","version_name":"${VERSION_NAME}","version_code":"${VERSION_CODE}","tag":"${TAG}","commit_sha":"${COMMIT_SHA}"}}
+          JSON
+
+      - name: Cleanup Keychain
+        if: always()
+        run: |
+          security delete-keychain build.keychain 2>/dev/null || true
+          # Restore original default keychain
+          if [ -n "$ORIGINAL_DEFAULT_KEYCHAIN" ]; then
+            security default-keychain -s "$ORIGINAL_DEFAULT_KEYCHAIN" 2>/dev/null || true
+          else
+            security default-keychain -s ~/Library/Keychains/login.keychain-db 2>/dev/null || true
+          fi
+          rm -f "$RUNNER_TEMP/private_keys/AuthKey.p8"
+
+      - name: Cleanup Build Cache
+        if: always()
+        run: |
+          if [ -n "${GIT_CONFIG_GLOBAL:-}" ]; then
+            rm -f "$GIT_CONFIG_GLOBAL"
+          fi
+          # Clean Xcode DerivedData
+          rm -rf ~/Library/Developer/Xcode/DerivedData/*Ham* 2>/dev/null || true
+          # Clean Xcode Archives
+          rm -rf ~/Library/Developer/Xcode/Archives 2>/dev/null || true
+          # Clean CocoaPods repos if not updated for over 30 days
+          if [ -d ~/.cocoapods/repos ]; then
+            REPOS_MTIME=$(stat -f %m ~/.cocoapods/repos)
+            NOW=$(date +%s)
+            AGE=$(( (NOW - REPOS_MTIME) / 86400 ))
+            if [ "$AGE" -gt 30 ]; then
+              echo "CocoaPods repos cache is ${AGE} days old, cleaning up..."
+              rm -rf ~/.cocoapods/repos
+            fi
+          fi

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -180,21 +180,12 @@ jobs:
           RELEASE_NOTES: ${{ github.event.client_payload.release_notes }}
           VERSION_NAME: ${{ steps.build.outputs.version_name }}
           VERSION_CODE: ${{ steps.build.outputs.version_code }}
-          TESTFLIGHT_URL: ${{ vars.IOS_TESTFLIGHT_URL }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if [ -z "$TESTFLIGHT_URL" ]; then
-            echo "::error::The IOS_TESTFLIGHT_URL repository variable is not set."
-            exit 1
-          fi
-          case "$TESTFLIGHT_URL" in
-            https://*|itms-beta://*) ;;
-            *)
-              echo "::error::IOS_TESTFLIGHT_URL must start with https:// or itms-beta://"
-              exit 1
-              ;;
-          esac
+          # Keep in sync with the fallback invite in
+          # docs/page/download/component/IOSDownloadPanel.vue.
+          TESTFLIGHT_URL="itms-beta://testflight.apple.com/join/waKNnCG3"
 
           # Checkout the docs site on a scratch path so the build workspace stays clean.
           DOCS_DIR="$RUNNER_TEMP/ham-docs"

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [self-hosted, macOS]
+    runs-on: macos-latest
     permissions:
       contents: read
     outputs:
@@ -39,9 +39,6 @@ jobs:
           PROTO_GIT_CONFIG="$RUNNER_TEMP/ham-proto-gitconfig"
           git config --file "$PROTO_GIT_CONFIG" url."https://x-access-token:${PROTO_REPO_TOKEN}@github.com/whu-ham/ham-proto.git".insteadOf "https://github.com/whu-ham/ham-proto.git"
           echo "GIT_CONFIG_GLOBAL=$PROTO_GIT_CONFIG" >> "$GITHUB_ENV"
-
-      - name: Clean node_modules
-        run: rm -rf node_modules
 
       - name: Setup Ruby
         run: |
@@ -187,23 +184,9 @@ jobs:
           fi
           rm -f "$RUNNER_TEMP/private_keys/AuthKey.p8"
 
-      - name: Cleanup Build Cache
+      - name: Cleanup proto git config
         if: always()
         run: |
           if [ -n "${GIT_CONFIG_GLOBAL:-}" ]; then
             rm -f "$GIT_CONFIG_GLOBAL"
-          fi
-          # Clean Xcode DerivedData
-          rm -rf ~/Library/Developer/Xcode/DerivedData/*Ham* 2>/dev/null || true
-          # Clean Xcode Archives
-          rm -rf ~/Library/Developer/Xcode/Archives 2>/dev/null || true
-          # Clean CocoaPods repos if not updated for over 30 days
-          if [ -d ~/.cocoapods/repos ]; then
-            REPOS_MTIME=$(stat -f %m ~/.cocoapods/repos)
-            NOW=$(date +%s)
-            AGE=$(( (NOW - REPOS_MTIME) / 86400 ))
-            if [ "$AGE" -gt 30 ]; then
-              echo "CocoaPods repos cache is ${AGE} days old, cleaning up..."
-              rm -rf ~/.cocoapods/repos
-            fi
           fi

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -107,6 +107,7 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          RELEASE_NOTES: ${{ github.event.client_payload.release_notes }}
           VERSION_NUMBER: ${{ github.event.client_payload.version_number }}
           BUILD_NUMBER: ${{ github.event.client_payload.build_number }}
           PUBLIC_TESTING: ${{ github.event.client_payload.distribution == 'public' }}
@@ -171,6 +172,53 @@ jobs:
             --data-binary @- <<JSON
           {"event_type":"ios-release-completed","client_payload":{"request_id":"${REQUEST_ID}","source_ref":"${SOURCE_REF}","version_name":"${VERSION_NAME}","version_code":"${VERSION_CODE}","tag":"${TAG}","commit_sha":"${COMMIT_SHA}"}}
           JSON
+
+      - name: Publish beta info to the docs site
+        env:
+          RELEASE_NOTES: ${{ github.event.client_payload.release_notes }}
+          VERSION_NAME: ${{ steps.build.outputs.version_name }}
+          VERSION_CODE: ${{ steps.build.outputs.version_code }}
+          TESTFLIGHT_URL: ${{ vars.IOS_TESTFLIGHT_URL }}
+          DOCS_REPO_TOKEN: ${{ secrets.HAM_DOCS_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "$TESTFLIGHT_URL" ]; then
+            echo "::error::The IOS_TESTFLIGHT_URL repository variable is not set."
+            exit 1
+          fi
+          case "$TESTFLIGHT_URL" in
+            https://*|itms-beta://*) ;;
+            *)
+              echo "::error::IOS_TESTFLIGHT_URL must start with https:// or itms-beta://"
+              exit 1
+              ;;
+          esac
+
+          # Checkout the docs site on a scratch path so the build workspace stays clean.
+          DOCS_DIR="$RUNNER_TEMP/ham-docs"
+          git clone --depth 1 "https://x-access-token:${DOCS_REPO_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$DOCS_DIR"
+
+          # Build the JSON with jq so notes containing quotes or newlines stay valid.
+          PUBLISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          jq -n \
+            --arg version_name "$VERSION_NAME" \
+            --arg version_code "$VERSION_CODE" \
+            --arg release_notes "$RELEASE_NOTES" \
+            --arg testflight_url "$TESTFLIGHT_URL" \
+            --arg published_at "$PUBLISHED_AT" \
+            '{version_name:$version_name,version_code:$version_code,release_notes:$release_notes,testflight_url:$testflight_url,published_at:$published_at}' \
+            > "$DOCS_DIR/docs/src/public/ios-beta.json"
+
+          cd "$DOCS_DIR"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/src/public/ios-beta.json
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(ios): publish beta ${VERSION_NAME} (${VERSION_CODE})"
+            git push origin HEAD:main
+          else
+            echo "Beta info unchanged, nothing to commit."
+          fi
 
       - name: Cleanup Keychain
         if: always()

--- a/docs/page/download/component/IOSBetaItem.vue
+++ b/docs/page/download/component/IOSBetaItem.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import {IOSBetaInfo} from '../service/ios_beta_fetch';
+import ArrowLink from '../../../components/ArrowLink.vue';
+import {formatDate} from '../service/date';
+import PreReleaseTag from './PreReleaseTag.vue';
+import {useDownloadI18n} from '../service/i18n';
+
+const {item} = defineProps<{
+  item: IOSBetaInfo;
+}>();
+const {t} = useDownloadI18n();
+
+const versionLabel = (item: IOSBetaInfo) =>
+  `${item.versionName} (${item.versionCode})`;
+</script>
+
+<template>
+  <div>
+    <div class="title-container">
+      <h3 class="title-text">{{ versionLabel(item) }}</h3>
+      <PreReleaseTag class="title-tag" />
+    </div>
+    <span class="caption"
+      >{{ t('publishedOn') }} {{ formatDate(item.publishedAt) }}</span
+    >
+
+    <blockquote v-if="item.releaseNotes">
+      <div v-html="item.releaseNotes.replace(/\n/g, '<br>')"></div>
+    </blockquote>
+
+    <ArrowLink :href="item.testflightUrl" :text="t('downloadOnTestflight')" />
+  </div>
+</template>
+
+<style scoped lang="scss">
+.title {
+  &-text {
+    margin-top: 0;
+    display: inline-block;
+  }
+
+  &-container {
+    display: flex;
+    align-content: center;
+    margin-top: 8px;
+    margin-bottom: 8px;
+  }
+
+  &-tag {
+    margin-left: 12px;
+    display: block;
+  }
+}
+</style>

--- a/docs/page/download/component/IOSDownloadPanel.vue
+++ b/docs/page/download/component/IOSDownloadPanel.vue
@@ -4,16 +4,20 @@ import {
   getLatestIOSVersionInfo,
   IOSVersionInfo,
 } from '../service/ios_version_fetch';
+import {getLatestIOSBetaInfo, IOSBetaInfo} from '../service/ios_beta_fetch';
 import ArrowLink from '../../../components/ArrowLink.vue';
 import {formatDate} from '../service/date';
 import NoticeView from './NoticeView.vue';
+import IOSBetaItem from './IOSBetaItem.vue';
 import {useDownloadI18n} from '../service/i18n';
 
 const versionInfo = ref<IOSVersionInfo>();
+const betaInfo = ref<IOSBetaInfo | null>(null);
 const {t} = useDownloadI18n();
 
 onMounted(async () => {
   versionInfo.value = await getLatestIOSVersionInfo();
+  betaInfo.value = await getLatestIOSBetaInfo();
 });
 </script>
 
@@ -33,19 +37,22 @@ onMounted(async () => {
     </div>
 
     <div>
-      <h3>{{ t('betaTitle') }}</h3>
-      <NoticeView :title="t('noticeTitle')">
-        <p>
-          {{ t('testflightPromptPrefix') }}
-          <ArrowLink
-            href="https://apps.apple.com/us/app/testflight/id899247664"
-            text="TestFlight" />
-          {{ t('testflightPromptSuffix') }}
-        </p>
-      </NoticeView>
-      <ArrowLink
-        href="itms-beta://testflight.apple.com/join/waKNnCG3"
-        :text="t('joinTestflight')" />
+      <IOSBetaItem v-if="betaInfo" :item="betaInfo" />
+      <div v-else>
+        <h3>{{ t('betaTitle') }}</h3>
+        <NoticeView :title="t('noticeTitle')">
+          <p>
+            {{ t('testflightPromptPrefix') }}
+            <ArrowLink
+              href="https://apps.apple.com/us/app/testflight/id899247664"
+              text="TestFlight" />
+            {{ t('testflightPromptSuffix') }}
+          </p>
+        </NoticeView>
+        <ArrowLink
+          href="itms-beta://testflight.apple.com/join/waKNnCG3"
+          :text="t('joinTestflight')" />
+      </div>
     </div>
   </div>
 </template>

--- a/docs/page/download/service/i18n.ts
+++ b/docs/page/download/service/i18n.ts
@@ -15,7 +15,8 @@ type MessageKey =
   | 'downloadLinksTitle'
   | 'downloadsSuffix'
   | 'download'
-  | 'preRelease';
+  | 'preRelease'
+  | 'downloadOnTestflight';
 
 const messages: Record<LocaleKey, Record<MessageKey, string>> = {
   zh: {
@@ -32,6 +33,7 @@ const messages: Record<LocaleKey, Record<MessageKey, string>> = {
     downloadsSuffix: '次下载',
     download: '下载',
     preRelease: '预发布',
+    downloadOnTestflight: '通过 TestFlight 下载',
   },
   en: {
     requestFailedTitle: 'Request failed',
@@ -48,6 +50,7 @@ const messages: Record<LocaleKey, Record<MessageKey, string>> = {
     downloadsSuffix: ' downloads',
     download: 'Download',
     preRelease: 'Pre-release',
+    downloadOnTestflight: 'Download on TestFlight',
   },
   ja: {
     requestFailedTitle: '取得に失敗しました',
@@ -63,6 +66,7 @@ const messages: Record<LocaleKey, Record<MessageKey, string>> = {
     downloadsSuffix: '回のダウンロード',
     download: 'ダウンロード',
     preRelease: 'プレリリース',
+    downloadOnTestflight: 'TestFlightでダウンロード',
   },
 };
 

--- a/docs/page/download/service/ios_beta_fetch.ts
+++ b/docs/page/download/service/ios_beta_fetch.ts
@@ -1,0 +1,59 @@
+/**
+ * Reads the iOS beta metadata that the release workflow publishes into
+ * `docs/src/public/ios-beta.json`.
+ *
+ * The file lives in the public directory so it is served as a static asset,
+ * which keeps the download page free of any GitHub API dependency.
+ *
+ * @author orangeboyChen
+ */
+import axios from 'axios';
+
+interface IOSBetaInfo {
+  versionName: string;
+  versionCode: string;
+  releaseNotes: string;
+  testflightUrl: string;
+  publishedAt: Date;
+}
+
+const BETA_INFO_PATH = '/ios-beta.json';
+
+const getLatestIOSBetaInfo = async (): Promise<IOSBetaInfo | null> => {
+  try {
+    const {data} = await axios.get(BETA_INFO_PATH);
+    // Guard against a partially written or hand-edited file. An empty seed
+    // file counts as "no beta published", so every required field must be a
+    // non-empty string.
+    const required = ['version_name', 'version_code', 'testflight_url'];
+    const hasAllFields =
+      !!data &&
+      required.every(
+        key => typeof data[key] === 'string' && data[key].trim() !== '',
+      );
+    if (!hasAllFields) {
+      return null;
+    }
+
+    const publishedAt = new Date(data.published_at);
+    return {
+      versionName: data.version_name,
+      versionCode: data.version_code,
+      releaseNotes:
+        typeof data.release_notes === 'string' ? data.release_notes : '',
+      testflightUrl: data.testflight_url,
+      // An unparseable date should degrade to "now" rather than "Invalid Date".
+      publishedAt: isNaN(publishedAt.getTime()) ? new Date() : publishedAt,
+    };
+  } catch (e) {
+    // A missing file simply means no beta has been published yet.
+    if (axios.isAxiosError(e) && e.response?.status === 404) {
+      return null;
+    }
+    throw e;
+  }
+};
+
+export type {IOSBetaInfo};
+
+export {getLatestIOSBetaInfo};

--- a/docs/page/download/service/ios_beta_fetch.ts
+++ b/docs/page/download/service/ios_beta_fetch.ts
@@ -2,8 +2,10 @@
  * Reads the iOS beta metadata that the release workflow publishes into
  * `docs/src/public/ios-beta.json`.
  *
- * The file lives in the public directory so it is served as a static asset,
- * which keeps the download page free of any GitHub API dependency.
+ * The file does not exist until the first beta is published, and it lives in
+ * the public directory so it is served as a static asset. That keeps the
+ * download page free of any GitHub API dependency, which matters because
+ * `ham-ios` is private and its releases are not readable from a browser.
  *
  * @author orangeboyChen
  */
@@ -22,9 +24,9 @@ const BETA_INFO_PATH = '/ios-beta.json';
 const getLatestIOSBetaInfo = async (): Promise<IOSBetaInfo | null> => {
   try {
     const {data} = await axios.get(BETA_INFO_PATH);
-    // Guard against a partially written or hand-edited file. An empty seed
-    // file counts as "no beta published", so every required field must be a
-    // non-empty string.
+    // Guard against a partially written or hand-edited file. Every required
+    // field must be a non-empty string, so a half-filled file degrades to
+    // "no beta published" instead of rendering blank values.
     const required = ['version_name', 'version_code', 'testflight_url'];
     const hasAllFields =
       !!data &&
@@ -46,9 +48,18 @@ const getLatestIOSBetaInfo = async (): Promise<IOSBetaInfo | null> => {
       publishedAt: isNaN(publishedAt.getTime()) ? new Date() : publishedAt,
     };
   } catch (e) {
-    // A missing file simply means no beta has been published yet.
-    if (axios.isAxiosError(e) && e.response?.status === 404) {
-      return null;
+    // The file does not exist until the first beta is published, so treat a
+    // missing asset as "no beta yet" instead of failing the page.
+    if (axios.isAxiosError(e)) {
+      const status = e.response?.status;
+      if (status === 404) {
+        return null;
+      }
+      // Some static hosts return the SPA shell instead of a 404, so a
+      // non-JSON response means the same thing.
+      if (typeof e.response?.data === 'string') {
+        return null;
+      }
     }
     throw e;
   }

--- a/docs/src/public/ios-beta.json
+++ b/docs/src/public/ios-beta.json
@@ -1,7 +1,0 @@
-{
-  "version_name": "",
-  "version_code": "",
-  "release_notes": "",
-  "testflight_url": "",
-  "published_at": ""
-}

--- a/docs/src/public/ios-beta.json
+++ b/docs/src/public/ios-beta.json
@@ -1,0 +1,7 @@
+{
+  "version_name": "",
+  "version_code": "",
+  "release_notes": "",
+  "testflight_url": "",
+  "published_at": ""
+}


### PR DESCRIPTION
Closes whu-ham/ham-workspace#9

## Summary

Publish Android beta releases straight to the releases page, fix the release-notes branch name, drop the redundant install-instructions section, centralize the iOS release build in this repository, add a build-only workflow for both platforms, and show the current iOS beta version on the download page.

## Changes

### Android release (`android-release.yml`)

- **Beta publishes directly.** Beta releases no longer pass `--draft`. They are created as visible pre-releases, so a beta run needs no manual publish step. Stable releases still stay as drafts for review.
- **Branch name corrected.** The generated notes said builds came from `master`. The Android repository builds from `main`, so the note now says `main`.
- **Install section removed.** The "📦 安装说明 / 请从下方附件中下载合适的 APK 安装包。" section only restated what the attached APKs already show, so it is gone.

### Manual builds (`android-build.yml`, `ios-build.yml`)

- `android-build.yml` now runs a new fastlane `build` lane instead of `beta`, so it no longer pushes artifacts to the Google Play internal track. The `GOOGLE_AUTH` key is no longer written to disk.
- `ios-build.yml` is new. It builds a signed IPA for any branch and uploads it as a workflow artifact, without distributing it on TestFlight.

Both share the release build steps verbatim, so a manual build exercises the same signing and packaging path as a release.

### iOS release (`ios-release.yml`, new)

Mirrors the Android pattern:

1. `ham-ios` dispatches `ios-release-requested` with the version number, build number, TestFlight distribution mode, external group, changelog, and release notes.
2. This repository builds, uploads to TestFlight and dSYMs to Crashlytics, commits the version bump, publishes the beta metadata, and sends an `ios-release-completed` callback.
3. `ham-ios` validates the callback, pushes the tag, and creates its own GitHub pre-release.

The build steps are carried over unchanged from the previous `ham-ios` `testflight.yml`; the only difference is that inputs come from `client_payload` rather than `inputs`. Two self-hosted maintenance steps were dropped, since `macos-latest` is ephemeral. The proto git config cleanup is kept because it removes a file holding a token.

No GitHub Release is created here for iOS, per the requirement.

### iOS beta on the download page

The download page previously offered only a fixed "Join TestFlight beta" link. It now renders the current beta's version name, build number, publication date, release notes, and a TestFlight download link, matching the Android layout.

After a successful TestFlight upload, the release workflow writes those fields to `docs/src/public/ios-beta.json` and commits the change. The page reads that static file and falls back to the previous TestFlight invitation while no beta is published, which is also the state right after this PR merges.

The metadata is a static asset rather than a GitHub API call because `ham-ios` is private, so its releases are not readable from a visitor's browser.

## Runner

The iOS jobs run on `macos-latest`, a GitHub-hosted runner, so no self-hosted macOS machine needs to be registered.

## Required configuration

- Secrets: `HAM_IOS_REPO_TOKEN`, `HAM_IOS_DISPATCH_TOKEN`, `PROTO_REPO_TOKEN`, and the App Store Connect and match set (`ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_CONTENT`, `MATCH_PASSWORD`, `MATCH_GIT_BASIC_AUTHORIZATION`, `KEYCHAIN_PASSWORD`). The publish step runs here, so it uses the built-in `github.token` and needs no extra secret; the job grants itself `contents: write`.
- No repository variables. The TestFlight invite is a public link that never changes between builds, so it is hardcoded in the workflow and kept in sync with the fallback link on the download page.

## Verification

- All workflows parse as YAML, and every embedded shell block passes `bash -n`.
- The shared iOS build steps were diffed field by field against the previous `testflight.yml`; apart from the input source, they are identical.
- `pnpm lint` and `pnpm docs:build` both pass. With no beta published, `ios-beta.json` is correctly absent from `dist`.
- The publish step was replayed against a throwaway repository with no pre-existing file; it created the directory, wrote valid JSON with the expected invite URL, and committed.
- The beta-info loader was exercised against empty, partial, malformed-date, and real payloads; only a complete payload renders the version panel, and a 404 returns the fallback.
- Dispatch and metadata payloads are built with `jq`, so quotes and newlines in release notes cannot break the JSON.
- Validation blocks reject malformed versions, build numbers, tags, commit SHAs, and distribution inputs. They fail fast with an explicit error, which a bare `[[ ]]` under `set -e` does not do.

## Companion PRs

- whu-ham/ham-android#94 — adds the fastlane `build` lane.
- whu-ham/ham-ios#76 — replaces `testflight.yml`, adds the `build` lane and the `release_notes` input.