### PR TITLE
perf(ci): speed up iOS and Android builds with CDN pods and caching

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: pnpm
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.2.0

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -50,7 +50,8 @@ jobs:
         uses: pnpm/action-setup@v4.2.0
         with:
           version: 10.6.4
-          run_install: true
+          # pod_install.sh runs `pnpm install` before applying the glog patch.
+          run_install: false
 
       - name: Bundle Install
         run: |
@@ -85,14 +86,41 @@ jobs:
           security set-keychain-settings -t 3600 -u build.keychain
           security list-keychains -d user -s build.keychain $(security list-keychains -d user | sed s/\"//g)
 
+      - name: Cache CocoaPods downloads
+        uses: actions/cache@v4
+        with:
+          # Only the download cache. ~/.cocoapods/repos is intentionally
+          # excluded: it held the multi-gigabyte git spec repo this workflow
+          # used before switching to CDN, and restoring it would cost more
+          # than it saves.
+          path: ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-cocoapods-${{ hashFiles('Ham/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cocoapods-
+
       - name: Install CocoaPods
-        run: gem install cocoapods --no-document
+        run: |
+          # Pin the version recorded in Ham/Podfile.lock, which must stay at
+          # 1.17.0. A newer CocoaPods rewrites every checksum in that file.
+          COCOAPODS_VERSION=$(awk -F': *' '/^COCOAPODS:/{print $2; exit}' Ham/Podfile.lock)
+          if [ -z "$COCOAPODS_VERSION" ]; then
+            echo "::error::Could not read the COCOAPODS version from Ham/Podfile.lock"
+            exit 1
+          fi
+          if gem list -i cocoapods --version "$COCOAPODS_VERSION" >/dev/null; then
+            echo "CocoaPods $COCOAPODS_VERSION already installed"
+          else
+            echo "Installing CocoaPods $COCOAPODS_VERSION"
+            gem install cocoapods --version "$COCOAPODS_VERSION" --no-document
+          fi
 
       - name: CocoaPods Install
         run: |
-          find ~/.cocoapods/repos -name "index.lock" -delete 2>/dev/null || true
-          cd Ham
-          pod install --repo-update
+          # Use the project's own script rather than calling `pod install`
+          # directly. It also applies the glog configure patch that
+          # `pnpm install` alone does not, and it runs without `--repo-update`
+          # because Podfile.lock pins every version.
+          ./pod_install.sh
 
       - name: Build IPA
         env:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: pnpm
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.2.0

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -56,7 +56,8 @@ jobs:
         uses: pnpm/action-setup@v4.2.0
         with:
           version: 10.6.4
-          run_install: true
+          # pod_install.sh runs `pnpm install` before applying the glog patch.
+          run_install: false
 
       - name: Bundle Install
         run: |
@@ -91,14 +92,41 @@ jobs:
           security set-keychain-settings -t 3600 -u build.keychain
           security list-keychains -d user -s build.keychain $(security list-keychains -d user | sed s/\"//g)
 
+      - name: Cache CocoaPods downloads
+        uses: actions/cache@v4
+        with:
+          # Only the download cache. ~/.cocoapods/repos is intentionally
+          # excluded: it held the multi-gigabyte git spec repo this workflow
+          # used before switching to CDN, and restoring it would cost more
+          # than it saves.
+          path: ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-cocoapods-${{ hashFiles('Ham/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cocoapods-
+
       - name: Install CocoaPods
-        run: gem install cocoapods --no-document
+        run: |
+          # Pin the version recorded in Ham/Podfile.lock, which must stay at
+          # 1.17.0. A newer CocoaPods rewrites every checksum in that file.
+          COCOAPODS_VERSION=$(awk -F': *' '/^COCOAPODS:/{print $2; exit}' Ham/Podfile.lock)
+          if [ -z "$COCOAPODS_VERSION" ]; then
+            echo "::error::Could not read the COCOAPODS version from Ham/Podfile.lock"
+            exit 1
+          fi
+          if gem list -i cocoapods --version "$COCOAPODS_VERSION" >/dev/null; then
+            echo "CocoaPods $COCOAPODS_VERSION already installed"
+          else
+            echo "Installing CocoaPods $COCOAPODS_VERSION"
+            gem install cocoapods --version "$COCOAPODS_VERSION" --no-document
+          fi
 
       - name: CocoaPods Install
         run: |
-          find ~/.cocoapods/repos -name "index.lock" -delete 2>/dev/null || true
-          cd Ham
-          pod install --repo-update
+          # Use the project's own script rather than calling `pod install`
+          # directly. It also applies the glog configure patch that
+          # `pnpm install` alone does not, and it runs without `--repo-update`
+          # because Podfile.lock pins every version.
+          ./pod_install.sh
 
       - name: Build & Upload to TestFlight
         id: build


### PR DESCRIPTION
Refs whu-ham/ham-workspace#9

## Summary

Both iOS workflows cloned the multi-gigabyte CocoaPods git spec repo on every run, and all four workflows re-downloaded the pnpm store from scratch. This removes both.

## Changes

### iOS: stop cloning the spec repo

Both workflows ran `pod install --repo-update`, which refreshes the entire spec repo every run even though `Podfile.lock` pins all 212 pods. Removing it is safe: the lockfile, not the spec repo, decides the versions.

The Podfile's move to the CDN is handled in the companion `ham-ios` PR.

### iOS: call `./pod_install.sh`

Beyond consolidating the command, this fixes a real gap. The workflows ran `pnpm install` and `pod install` but skipped the glog configure patch the script applies, so CI built against an unpatched React Native glog script.

### iOS: pin CocoaPods to 1.17.0

`Podfile.lock` records `COCOAPODS: 1.17.0`, and a newer CocoaPods rewrites every checksum in that file. The previous unpinned `gem install cocoapods` would eventually have pulled a new version and caused exactly that. The step now reads the version from the lockfile and installs it explicitly.

### iOS: cache CocoaPods downloads

Keyed on `Podfile.lock`, so the cache invalidates when dependencies change. It deliberately **excludes** `~/.cocoapods/repos`: that directory is where the multi-gigabyte git spec repo lived, and restoring it would cost more than it saves now that pods resolve over CDN.

### All four workflows: cache the pnpm store

Enable `actions/setup-node`'s built-in `cache: pnpm`. It derives the key from the lockfile and resolves the right store path per platform, which a hand-written `actions/cache` step would have to hardcode — I confirmed my own local store path is a machine-specific override, so a hardcoded path would have been wrong on CI.

Android already cached Gradle through `gradle/actions/setup-gradle` and has `org.gradle.caching` and `org.gradle.parallel` enabled, so it needed nothing else.

## Verification

- All four workflows parse as YAML and every embedded shell block passes `bash -n`.
- `./pod_install.sh` completes from a clean `node_modules` in about 25 seconds with CocoaPods 1.17.0.
- The CocoaPods version-extraction command was tested against lockfiles containing `1.17.0`, `2.0.0`, and no version at all; only the last triggers the error branch.
- `pnpm-lock.yaml` sits at the root of each checked-out repository, so `cache: pnpm` finds it without extra configuration.

## Companion PR

- whu-ham/ham-ios#77 — switches the Podfile to the CDN and regenerates `Podfile.lock`.