### PR TITLE
fix(ci): install pnpm before setup-node in the iOS workflows

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -42,17 +42,17 @@ jobs:
           echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
           echo "$(gem environment gemdir)/bin" >> $GITHUB_PATH
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.2.0
         with:
           version: 10.6.4
           # pod_install.sh runs `pnpm install` before applying the glog patch.
           run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
 
       - name: Bundle Install
         run: |

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -48,17 +48,17 @@ jobs:
           echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
           echo "$(gem environment gemdir)/bin" >> $GITHUB_PATH
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.2.0
         with:
           version: 10.6.4
           # pod_install.sh runs `pnpm install` before applying the glog patch.
           run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
 
       - name: Bundle Install
         run: |


### PR DESCRIPTION
Refs whu-ham/ham-workspace#9

## Problem

The iOS Manual Build workflow failed at `actions/setup-node@v4`:

```
##[error]Unable to locate executable file: pnpm. Please verify either the
file path exists or the file can be found within a directory specified by
the PATH environment variable.
```

Run: https://github.com/whu-ham/whu-ham.github.io/actions/runs/34221996057/job/102047053023

## Cause

`cache: pnpm` makes setup-node resolve the pnpm store path by invoking the pnpm binary, so pnpm has to be on PATH when setup-node runs.

The iOS workflows declared `actions/setup-node` first and `pnpm/action-setup` second, so pnpm did not exist yet. The Android workflows already had the correct order, which is why only iOS failed.

## Fix

Match the Android ordering in both iOS workflows: set up pnpm first, then Node with the cache enabled.

Android also passes a `dest` to `pnpm/action-setup`, and its setup-node step works, so `dest` is not a factor and iOS does not need one.

## Verification

- All four workflows now resolve to the same order, checked by parsing the YAML rather than reading it:
  - `android-build -> pnpm, node`
  - `android-release -> pnpm, node`
  - `ios-build -> pnpm, node`
  - `ios-release -> pnpm, node`
- The only diff is the two swapped step blocks; no other step changed.