### PR TITLE
perf(ios): cache SwiftPM artifacts across runs

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -99,6 +99,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cocoapods-
 
+      - name: Cache SwiftPM artifacts
+        uses: actions/cache@v4
+        with:
+          # Binary artifacts (the protoc bundle, OpenSSL.xcframework) and the
+          # cloned package repositories. Both the SwiftPM CLI and xcodebuild
+          # read them from here, so a hit means neither has to download.
+          path: |
+            ~/Library/Caches/org.swift.swiftpm/artifacts
+            ~/Library/Caches/org.swift.swiftpm/repositories
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('Ham/Ham.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'Component/HamProtobuf/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-
+
       - name: Install CocoaPods
         run: |
           # Pin the version recorded in Ham/Podfile.lock, which must stay at

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -105,6 +105,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cocoapods-
 
+      - name: Cache SwiftPM artifacts
+        uses: actions/cache@v4
+        with:
+          # Binary artifacts (the protoc bundle, OpenSSL.xcframework) and the
+          # cloned package repositories. Both the SwiftPM CLI and xcodebuild
+          # read them from here, so a hit means neither has to download.
+          path: |
+            ~/Library/Caches/org.swift.swiftpm/artifacts
+            ~/Library/Caches/org.swift.swiftpm/repositories
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('Ham/Ham.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'Component/HamProtobuf/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-
+
       - name: Install CocoaPods
         run: |
           # Pin the version recorded in Ham/Podfile.lock, which must stay at


### PR DESCRIPTION
Refs whu-ham/ham-workspace#9

## Problem

iOS builds hang on `macos-latest` after printing:

```
Downloading binary artifact .../protoc-32.1.artifactbundle.zip
```

This is [actions/runner-images#13175](https://github.com/actions/runner-images/issues/13175), still open, affecting macOS 15 Arm64. The hang is inside xcodebuild's package resolution, so it cannot be fixed from the caller side, and `xcodebuild -resolvePackageDependencies` cannot be used as a pre-step because it is the command that hangs.

## Fix

Cache the SwiftPM artifacts and package repositories, so a cache hit means no download happens and the hanging path is avoided entirely rather than raced.

```yaml
path: |
  ~/Library/Caches/org.swift.swiftpm/artifacts
  ~/Library/Caches/org.swift.swiftpm/repositories
```

Both the SwiftPM CLI and xcodebuild read from this shared location, so this benefits both resolution paths in the build.

## Cache key

Keyed on both package graphs the build resolves:

- `Ham/Ham.xcworkspace/xcshareddata/swiftpm/Package.resolved` — 27 pins
- `Component/HamProtobuf/Package.resolved` — 20 pins

These are genuinely different graphs: they pin different versions of the same packages (for example swift-protobuf 1.33.3 vs 1.32.0), so both files are needed for the key to invalidate correctly.

`Podfile.lock` is deliberately not part of the key, since it does not affect SwiftPM resolution.

## Verification

- Both workflows parse as YAML and every embedded shell block passes `bash -n`.
- Both `hashFiles` paths were checked to exist in the checked-out `ham-ios` repository.

## Companion PR

- whu-ham/ham-ios#78 — pre-resolves the HamProtobuf package before `pod install`, which is where the observed hang occurred.