### PR TITLE
fix(ios): install protobuf before pod install

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -42,6 +42,15 @@ jobs:
           echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
           echo "$(gem environment gemdir)/bin" >> $GITHUB_PATH
 
+      - name: Install protobuf
+        run: |
+          # The Podfile's post_install hook shells out to `protoc` to generate
+          # the HamProtobuf Swift sources. That binary is not preinstalled on
+          # GitHub-hosted macOS runners, so the step fails with
+          # "Failed to generate HamProtobuf Swift sources".
+          brew install protobuf
+          protoc --version
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.2.0
         with:

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -48,6 +48,15 @@ jobs:
           echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
           echo "$(gem environment gemdir)/bin" >> $GITHUB_PATH
 
+      - name: Install protobuf
+        run: |
+          # The Podfile's post_install hook shells out to `protoc` to generate
+          # the HamProtobuf Swift sources. That binary is not preinstalled on
+          # GitHub-hosted macOS runners, so the step fails with
+          # "Failed to generate HamProtobuf Swift sources".
+          brew install protobuf
+          protoc --version
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.2.0
         with:


### PR DESCRIPTION
Refs whu-ham/ham-workspace#9

## Problem

The iOS Manual Build fails at CocoaPods Install:

```
Build of product 'protoc-gen-grpc-swift' complete! (24.98s)
Failed to generate HamProtobuf Swift sources
  Podfile:139:in 'block in generate_ham_protobuf'
```

Run: https://github.com/whu-ham/whu-ham.github.io/actions/runs/34225944730/job/102059981608

## Cause

The Podfile's `post_install` hook compiles the protoc plugin with `swift build`, then shells out to `protoc` to generate the Swift sources:

```ruby
system('protoc', '--proto_path=.', ...)
```

`protoc` is not preinstalled on GitHub-hosted macOS runners, and the workflows only installed Ruby via Homebrew.

This was masked until now by the SwiftPM binary artifact hang in the same step. With #89 working around the hang, the missing binary became the next failure.

## Fix

Install protobuf with Homebrew next to the existing Ruby setup.

The version is deliberately **not pinned**. The generated code has to stay in step with the swift-protobuf runtime that `Component/HamProtobuf/Package.resolved` pins (1.32.0), so pinning a separate version here would silently diverge from the source of truth.

## Verification

- Both workflows parse as YAML and every embedded shell block passes `bash -n`.
- `protoc --version` is printed in the step so the resolved version is visible in the log.

## Note

The same run also confirms the #89 workaround works: the artifact download completed in 1.49s and the plugin built in 24.98s, where it previously hung for 15 minutes.