### PR TITLE
ci: fix iOS build toolchain and Android release notes

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -198,6 +198,27 @@ jobs:
         with:
           name: release-apks
           path: apks
+      - name: Resolve previous public release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_TYPE: ${{ github.event.client_payload.build_type }}
+        run: |
+          set -euo pipefail
+          # Public releases here use a different tag scheme (v1.7.6-beta2) from
+          # the Android repository the notes are generated in (v1.7.6.191-beta).
+          # The commit range has to come from the Android tags, since those are
+          # real git refs, but the notes should show the public name users see.
+          if [ "$BUILD_TYPE" = "release" ]; then
+            PREVIOUS_PUBLIC_TAG=$(gh release list --repo "$GITHUB_REPOSITORY" \
+              --limit 100 --json tagName,isPrerelease \
+              --jq '[.[] | select(.isPrerelease | not)][0].tagName // empty' || true)
+          else
+            PREVIOUS_PUBLIC_TAG=$(gh release list --repo "$GITHUB_REPOSITORY" \
+              --limit 100 --json tagName,isPrerelease \
+              --jq '[.[] | select(.isPrerelease)][0].tagName // empty' || true)
+          fi
+          echo "PREVIOUS_PUBLIC_TAG=$PREVIOUS_PUBLIC_TAG" >> "$GITHUB_ENV"
+
       - name: Generate release notes
         id: release-notes
         env:
@@ -210,19 +231,27 @@ jobs:
           NOTES_FILE="$RUNNER_TEMP/release-notes.md"
           echo "RELEASE_NOTES_FILE=$NOTES_FILE" >> "$GITHUB_ENV"
 
+          # Cap the commit list so a long release window cannot produce an
+          # unusable wall of text.
+          MAX_COMMITS=50
+
+          # Set by the previous step. Fall back to the Android tag when the
+          # public release lookup came back empty.
+          PREVIOUS_PUBLIC_TAG="${PREVIOUS_PUBLIC_TAG:-}"
+
           if [ "$BUILD_TYPE" = "beta" ]; then
-            PREVIOUS_TAG=$(git tag --list 'v*-beta' --sort=-version:refname | head -n 1 || true)
+            PREVIOUS_TAG=$(git tag --list 'v*-beta*' --sort=-version:refname | head -n 1 || true)
             TITLE="## 🚀 Beta - ${VERSION_NAME} (${VERSION_CODE})"
             BUILD_NOTE="> 此版本由 \`main\` 分支自动构建。"
             IMPORTANT_NOTE_1="- 这是自动生成的 Beta 构建，不建议在生产环境使用。"
             IMPORTANT_NOTE_2="- 已上传到 Google Play 内部测试。"
             IMPORTANT_NOTE_3="- Beta 版本可能包含不稳定或未完成的变更，请谨慎使用。"
           else
-            PREVIOUS_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -Ev -- '-beta$' | head -n 1 || true)
+            PREVIOUS_TAG=$(git tag --list 'v*' --sort=-version:refname | grep -Ev -- '-beta' | head -n 1 || true)
             TITLE="## 🎉 Release - ${VERSION_NAME} (${VERSION_CODE})"
             BUILD_NOTE="> 此版本由 \`main\` 分支自动构建。"
             IMPORTANT_NOTE_1="- 已上传到 Google Play 内部测试。"
-            IMPORTANT_NOTE_2="- 请从下方附件中下载合适的 APK 安装包。"
+            IMPORTANT_NOTE_2=""
             IMPORTANT_NOTE_3=""
           fi
 
@@ -231,6 +260,10 @@ jobs:
             COMMITS=$(git log "${PREVIOUS_TAG}..${{ github.event.client_payload.source_ref }}" --no-merges --pretty=format:'- `%h` %s (%an)' | grep -Fv 'chore: bump version to ' || true)
           fi
           COMMIT_COUNT=$(printf '%s\n' "$COMMITS" | sed '/^$/d' | wc -l | tr -d ' ')
+          SHOWN_COMMITS="$COMMITS"
+          if [ "$COMMIT_COUNT" -gt "$MAX_COMMITS" ]; then
+            SHOWN_COMMITS=$(printf '%s\n' "$COMMITS" | sed '/^$/d' | head -n "$MAX_COMMITS")
+          fi
 
           {
             echo "$TITLE"
@@ -244,25 +277,34 @@ jobs:
             echo "### 🔍 提交信息"
             echo
             if [ -n "$PREVIOUS_TAG" ]; then
-              echo "- 基于 \`${PREVIOUS_TAG}\` 之后的变更"
-              echo "- 提交数量：${COMMIT_COUNT}"
+              # A blockquote, so GitHub can never join this line to the
+              # commit list that follows it.
+              if [ -n "$PREVIOUS_PUBLIC_TAG" ]; then
+                echo "> 基于 \`${PREVIOUS_PUBLIC_TAG}\` 之后的变更，提交数量：${COMMIT_COUNT}"
+              else
+                echo "> 基于 \`${PREVIOUS_TAG}\` 之后的变更，提交数量：${COMMIT_COUNT}"
+              fi
               echo
-              if [ -n "$COMMITS" ]; then
-                echo "$COMMITS"
+              if [ -n "$SHOWN_COMMITS" ]; then
+                echo "$SHOWN_COMMITS"
+                if [ "$COMMIT_COUNT" -gt "$MAX_COMMITS" ]; then
+                  echo
+                  echo "- 仅显示最近 ${MAX_COMMITS} 条提交，完整列表见提交历史。"
+                fi
               else
                 echo "- 该范围内没有匹配的提交。"
               fi
             else
-              echo "- 未找到符合条件的上一版本标签。"
+              echo "未找到符合条件的上一版本标签。"
             fi
             echo
             echo "### ⚠️ 注意事项"
             echo
-            echo "$IMPORTANT_NOTE_1"
-            echo "$IMPORTANT_NOTE_2"
-            if [ -n "$IMPORTANT_NOTE_3" ]; then
-              echo "$IMPORTANT_NOTE_3"
-            fi
+            for NOTE in "$IMPORTANT_NOTE_1" "$IMPORTANT_NOTE_2" "$IMPORTANT_NOTE_3"; do
+              if [ -n "$NOTE" ]; then
+                echo "$NOTE"
+              fi
+            done
             echo
           } > "$NOTES_FILE"
 

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -133,6 +133,57 @@ jobs:
             gem install cocoapods --version "$COCOAPODS_VERSION" --no-document
           fi
 
+      - name: Pre-resolve Xcode workspace Swift packages
+        run: |
+          # xcodebuild resolves the workspace's 27 Swift packages itself, and
+          # on macOS runners that hangs indefinitely:
+          #
+          #   https://github.com/actions/runner-images/issues/13175 (still open)
+          #
+          # The SwiftPM CLI resolves the same graph reliably and writes to the
+          # same shared cache (~/Library/Caches/org.swift.swiftpm) that
+          # xcodebuild reads, so warming it here lets xcodebuild work from the
+          # cache instead of resolving over the network.
+          #
+          # The Xcode project has no Package.swift of its own -- its packages
+          # live in project.pbxproj -- so build a throwaway one from the
+          # workspace's Package.resolved, pinning every version exactly.
+          RESOLVED="Ham/Ham.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+          WARM_DIR="$RUNNER_TEMP/swiftpm-warm"
+          mkdir -p "$WARM_DIR"
+          python3 - "$RESOLVED" "$WARM_DIR/Package.swift" <<'PY'
+          import json, sys
+          resolved_path, out_path = sys.argv[1], sys.argv[2]
+          with open(resolved_path) as handle:
+              pins = json.load(handle).get("pins", [])
+          if not pins:
+              sys.exit("No pins found in %s" % resolved_path)
+          lines = [
+              "// swift-tools-version: 5.9",
+              "import PackageDescription",
+              "",
+              "let package = Package(",
+              '    name: "SwiftPMWarmCache",',
+              "    products: [],",
+              "    dependencies: [",
+          ]
+          for index, pin in enumerate(sorted(pins, key=lambda p: p["identity"])):
+              version = pin.get("state", {}).get("version")
+              if not version:
+                  continue
+              comma = "," if index < len(pins) - 1 else ""
+              lines.append('        .package(url: "%s", exact: "%s")%s'
+                           % (pin["location"], version, comma))
+          lines += ["    ],", "    targets: []", ")"]
+          with open(out_path, "w") as handle:
+              handle.write("\n".join(lines) + "\n")
+          print("Wrote %s with %d dependencies" % (out_path, len(pins)))
+          PY
+          cd "$WARM_DIR"
+          # One operation at a time: concurrent fetches are what make the
+          # xcodebuild path hang, and serialising them was reported to fix it.
+          env SWIFTPM_MAX_CONCURRENT_OPERATIONS=1 swift package resolve
+
       - name: CocoaPods Install
         run: |
           # Use the project's own script rather than calling `pod install`
@@ -142,6 +193,10 @@ jobs:
           ./pod_install.sh
 
       - name: Build IPA
+        # The default job timeout is 6 hours, and the SwiftPM hang shows up as
+        # silence rather than an error, so cap this step explicitly. The bound
+        # is generous because a cold archive of this workspace takes a while.
+        timeout-minutes: 120
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
@@ -150,14 +205,6 @@ jobs:
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: fastlane ios build
-
-      - name: Upload IPA
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-manual-build
-          path: fastlane/build/ham.ipa
-          retention-days: 7
-          if-no-files-found: error
 
       - name: Cleanup Keychain
         if: always()

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -36,11 +36,19 @@ jobs:
           git config --file "$PROTO_GIT_CONFIG" url."https://x-access-token:${PROTO_REPO_TOKEN}@github.com/whu-ham/ham-proto.git".insteadOf "https://github.com/whu-ham/ham-proto.git"
           echo "GIT_CONFIG_GLOBAL=$PROTO_GIT_CONFIG" >> "$GITHUB_ENV"
 
-      - name: Setup Ruby
+      - name: Install fastlane
         run: |
-          brew install ruby
-          echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
-          echo "$(gem environment gemdir)/bin" >> $GITHUB_PATH
+          # fastlane is the only thing the Ruby toolchain was installed for:
+          # the Gemfile lists just `gem "fastlane"`, there is no
+          # fastlane/Pluginfile, and the lane uses only built-in actions.
+          # Installing it with brew instead of Bundler also avoids a PATH
+          # conflict: `brew install ruby` upgrades the runner's Ruby 3.4 to
+          # 4.0, but /opt/homebrew/lib/ruby/gems/3.4.0/bin/bundle shadows the
+          # new one, so `bundle install` and `bundle exec fastlane` end up
+          # looking in different gem directories and the latter fails with
+          # "Could not find fastlane-... in locally installed gems".
+          brew install fastlane
+          fastlane --version
 
       - name: Install protobuf
         run: |
@@ -62,18 +70,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Bundle Install
-        run: |
-          # 1) Read Bundler version from Gemfile.lock
-          BUNDLER_VERSION=$(ruby -e 'lock = File.read("Gemfile.lock"); puts lock[/BUNDLED WITH\n\s+([\d.]+)/, 1]')
-
-          # 2) Install the locked Bundler version to fix environment mismatch
-          gem install bundler -v "$BUNDLER_VERSION" --no-document
-
-          # 3) Run Bundler using an absolute path from RubyGems bindir (most reliable)
-          #    This ensures we call the executable from the active RubyGems environment.
-          "$(ruby -e 'print Gem.bindir')/bundle" install
 
       - name: Setup App Store Connect API Key
         env:
@@ -153,7 +149,7 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: bundle exec fastlane ios build
+        run: fastlane ios build
 
       - name: Upload IPA
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -42,11 +42,19 @@ jobs:
           git config --file "$PROTO_GIT_CONFIG" url."https://x-access-token:${PROTO_REPO_TOKEN}@github.com/whu-ham/ham-proto.git".insteadOf "https://github.com/whu-ham/ham-proto.git"
           echo "GIT_CONFIG_GLOBAL=$PROTO_GIT_CONFIG" >> "$GITHUB_ENV"
 
-      - name: Setup Ruby
+      - name: Install fastlane
         run: |
-          brew install ruby
-          echo "$(brew --prefix ruby)/bin" >> $GITHUB_PATH
-          echo "$(gem environment gemdir)/bin" >> $GITHUB_PATH
+          # fastlane is the only thing the Ruby toolchain was installed for:
+          # the Gemfile lists just `gem "fastlane"`, there is no
+          # fastlane/Pluginfile, and the lane uses only built-in actions.
+          # Installing it with brew instead of Bundler also avoids a PATH
+          # conflict: `brew install ruby` upgrades the runner's Ruby 3.4 to
+          # 4.0, but /opt/homebrew/lib/ruby/gems/3.4.0/bin/bundle shadows the
+          # new one, so `bundle install` and `bundle exec fastlane` end up
+          # looking in different gem directories and the latter fails with
+          # "Could not find fastlane-... in locally installed gems".
+          brew install fastlane
+          fastlane --version
 
       - name: Install protobuf
         run: |
@@ -68,18 +76,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Bundle Install
-        run: |
-          # 1) Read Bundler version from Gemfile.lock
-          BUNDLER_VERSION=$(ruby -e 'lock = File.read("Gemfile.lock"); puts lock[/BUNDLED WITH\n\s+([\d.]+)/, 1]')
-
-          # 2) Install the locked Bundler version to fix environment mismatch
-          gem install bundler -v "$BUNDLER_VERSION" --no-document
-
-          # 3) Run Bundler using an absolute path from RubyGems bindir (most reliable)
-          #    This ensures we call the executable from the active RubyGems environment.
-          "$(ruby -e 'print Gem.bindir')/bundle" install
 
       - name: Setup App Store Connect API Key
         env:
@@ -166,7 +162,7 @@ jobs:
           PUBLIC_TESTING: ${{ github.event.client_payload.distribution == 'public' }}
           EXTERNAL_TESTING_GROUP: ${{ github.event.client_payload.external_testing_group }}
           CHANGELOG: ${{ github.event.client_payload.changelog }}
-        run: bundle exec fastlane ios beta
+        run: fastlane ios beta
 
       - name: Validate build outputs
         env:


### PR DESCRIPTION
Refs whu-ham/ham-workspace#9

Three changes.

## 1. Install fastlane with brew instead of Bundler

Once `CocoaPods Install` was fixed, the build reached `Build IPA` and failed:

```
bundler: failed to load command: fastlane (/opt/homebrew/lib/ruby/gems/3.4.0/bin/fastlane)
Could not find fastlane-2.234.0, aws-sdk-s3-1.223.0, ... in locally installed gems (Bundler::GemNotFound)
```

The workflows ran `brew install ruby` then `bundle install`, but the only thing they needed was fastlane:

- `Gemfile` is a single line: `gem "fastlane"`
- There is no `fastlane/Pluginfile`
- Every action used by the lanes is built-in

`brew install ruby` upgrades the runner's Ruby 3.4 to 4.0, but `/opt/homebrew/lib/ruby/gems/3.4.0/bin/bundle` stays earlier on `PATH` and shadows the new bundler (brew warns about this itself). Gems install into one Ruby's directory while `bundle exec fastlane` resolves against another's.

This is pre-existing, not a regression: earlier runs failed at `CocoaPods Install` and never reached this step.

Install fastlane with brew and invoke it directly, dropping the Ruby upgrade and the Bundler indirection. Verified the brew formula provides every action the lanes use: `match`, `build_app`, `upload_to_testflight`, `app_store_connect_api_key`, `increment_build_number`, `increment_version_number`, `update_code_signing_settings`, `disable_automatic_code_signing`, `upload_symbols_to_crashlytics`.

Note the brew formula tracks its own release, not `Gemfile.lock`, so it installs a newer fastlane than the locked 2.234.0. The Gemfile pins no version, so this is not a change in policy.

## 2. Pre-resolve the Xcode workspace's Swift packages, and drop the IPA upload

`Build IPA` then hung indefinitely, with no output. xcodebuild resolves the workspace's 27 Swift packages itself and on macOS runners that never finishes:

  https://github.com/actions/runner-images/issues/13175 (still open)

A maintainer attributes this to Xcode's SwiftPM resolution in a virtual environment, and reporters confirm the usual mitigations (`-scmProvider system`, `.netrc`, credential helpers) no longer help.

Those packages had no `Package.swift` -- they live in `project.pbxproj`, so the SwiftPM CLI had nothing to read. This generates a throwaway one from the workspace's `Package.resolved`, pinning every version exactly, and resolves it with the CLI.

That works because the SwiftPM CLI and xcodebuild share `~/Library/Caches/org.swift.swiftpm`: warming it means xcodebuild finds everything cached instead of resolving over the network. Fetches are serialised with `SWIFTPM_MAX_CONCURRENT_OPERATIONS=1`, which was reported to fix the hang where other attempts failed.

Also:

- Cap `Build IPA` at 120 minutes. The job timeout defaults to 6 hours and the hang produces no output, so a stuck run would burn the whole budget before failing. The bound stays generous because a cold archive of this workspace takes a while.
- Drop the signed-IPA upload. It stored `ham.ipa` as a workflow artifact that anyone with access to the run can download, and this repository is public, which exposed the built app and its embedded provisioning profiles. `Build IPA` still runs, so the workflow keeps verifying that a signed archive can be produced.

The Xcode version is left at the runner default.

## 3. Correct the Android release notes

Show the public release tag. The notes are generated in the Android repository, whose tags look like `v1.7.6.191-beta`, but releases are published here under a different scheme (`v1.7.6-beta2`). The commit range still has to come from the Android tags, since those are the real git refs, so the previous public release is resolved separately and displayed instead, falling back to the Android tag when the lookup is empty.

Stop rendering the range metadata as list items. `基于 <tag> 之后的变更` and `提交数量：<n>` each got a bullet, which reads as if they were commits, and GitHub joined the count line to the commit list below. They are now one blockquote line, which cannot merge with the list.

Stable releases picked the previous tag with `grep -Ev -- '-beta$'`, which only excludes tags ending in `-beta`. Android tags are named like `v1.7.6.191-beta`, so a release could diff against a beta and hide every beta commit since the last stable release. Exclude `-beta` anywhere in the name; a release now spans from the previous stable release. On the current repository this grows the release notes from 4 commits to 32.

Beta releases used the pattern `v*-beta`, matching only tags ending in `-beta`. Widened to `v*-beta*` for the tags actually in use.

Drop the install-instructions note (`请从下方附件中下载合适的 APK 安装包。`). Empty notes are skipped, so no blank lines are left behind.

Cap the list at 50 commits. A long release window produced an unusable wall of text; when the cap applies the count still reflects the full range and a note says the list is truncated.

Verified by running the generated block against the real ham-android repository for both beta and release, with and without a public tag, and with the cap lowered to confirm the truncation note.

## Note

`android-build.yml` and `android-release.yml` still use `bundle exec fastlane` with their own setup. Changing Android's Ruby setup is outside this issue's scope.

All workflow files parse as valid YAML. No workflow in this PR uploads artifacts any more.
