### PR TITLE
fix(ci): apply the SwiftPM warm-up to the iOS release workflow

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -139,6 +139,57 @@ jobs:
             gem install cocoapods --version "$COCOAPODS_VERSION" --no-document
           fi
 
+      - name: Pre-resolve Xcode workspace Swift packages
+        run: |
+          # xcodebuild resolves the workspace's 27 Swift packages itself, and
+          # on macOS runners that hangs indefinitely:
+          #
+          #   https://github.com/actions/runner-images/issues/13175 (still open)
+          #
+          # The SwiftPM CLI resolves the same graph reliably and writes to the
+          # same shared cache (~/Library/Caches/org.swift.swiftpm) that
+          # xcodebuild reads, so warming it here lets xcodebuild work from the
+          # cache instead of resolving over the network.
+          #
+          # The Xcode project has no Package.swift of its own -- its packages
+          # live in project.pbxproj -- so build a throwaway one from the
+          # workspace's Package.resolved, pinning every version exactly.
+          RESOLVED="Ham/Ham.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+          WARM_DIR="$RUNNER_TEMP/swiftpm-warm"
+          mkdir -p "$WARM_DIR"
+          python3 - "$RESOLVED" "$WARM_DIR/Package.swift" <<'PY'
+          import json, sys
+          resolved_path, out_path = sys.argv[1], sys.argv[2]
+          with open(resolved_path) as handle:
+              pins = json.load(handle).get("pins", [])
+          if not pins:
+              sys.exit("No pins found in %s" % resolved_path)
+          lines = [
+              "// swift-tools-version: 5.9",
+              "import PackageDescription",
+              "",
+              "let package = Package(",
+              '    name: "SwiftPMWarmCache",',
+              "    products: [],",
+              "    dependencies: [",
+          ]
+          for index, pin in enumerate(sorted(pins, key=lambda p: p["identity"])):
+              version = pin.get("state", {}).get("version")
+              if not version:
+                  continue
+              comma = "," if index < len(pins) - 1 else ""
+              lines.append('        .package(url: "%s", exact: "%s")%s'
+                           % (pin["location"], version, comma))
+          lines += ["    ],", "    targets: []", ")"]
+          with open(out_path, "w") as handle:
+              handle.write("\n".join(lines) + "\n")
+          print("Wrote %s with %d dependencies" % (out_path, len(pins)))
+          PY
+          cd "$WARM_DIR"
+          # One operation at a time: concurrent fetches are what make the
+          # xcodebuild path hang, and serialising them was reported to fix it.
+          env SWIFTPM_MAX_CONCURRENT_OPERATIONS=1 swift package resolve
+
       - name: CocoaPods Install
         run: |
           # Use the project's own script rather than calling `pod install`
@@ -149,6 +200,10 @@ jobs:
 
       - name: Build & Upload to TestFlight
         id: build
+        # The default job timeout is 6 hours, and the SwiftPM hang shows up as
+        # silence rather than an error, so cap this step explicitly. The bound
+        # is generous because a cold archive of this workspace takes a while.
+        timeout-minutes: 120
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}


### PR DESCRIPTION
Refs whu-ham/ham-workspace#9

## Problem

#91 added two fixes to `ios-build.yml` only:

- the SwiftPM warm-up step, so xcodebuild does not have to resolve the workspace's 27 Swift packages over the network
- a 120-minute cap on the build step

`ios-release.yml` was left with the original steps. It is the workflow that actually ships to TestFlight, so it is the one that most needs both.

## Why it matters

Without the warm-up, xcodebuild resolves those packages itself and hangs indefinitely on macOS runners:

  https://github.com/actions/runner-images/issues/13175 (still open)

The hang produces no output, so it is only visible as a step that never finishes. That is exactly what `Build IPA` did before the warm-up was added to `ios-build.yml`.

Without the cap, a hang burns the 6-hour default job budget before failing.

## Change

Add the same `Pre-resolve Xcode workspace Swift packages` step before `CocoaPods Install`, and the same `timeout-minutes: 120` on `Build & Upload to TestFlight`. The step is byte-identical to the one in `ios-build.yml`.

Both iOS workflows now warm the cache and bound their build step the same way.

## Verification

Both files parse as valid YAML, and the step lists confirm the warm-up and the cap are present in each:

```
ios-build.yml    Pre-resolve ... : yes    Build IPA timeout: 120
ios-release.yml  Pre-resolve ... : yes    Build & Upload to TestFlight timeout: 120
```
