### PR TITLE
fix(ci): only publish public TestFlight builds to the docs site

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -278,6 +278,10 @@ jobs:
           JSON
 
       - name: Publish beta info to the docs site
+        # Internal builds go to the internal TestFlight group only. The docs
+        # site is public and links to a public TestFlight invite, so an
+        # internal build must not appear there.
+        if: ${{ github.event.client_payload.distribution == 'public' }}
         env:
           RELEASE_NOTES: ${{ github.event.client_payload.release_notes }}
           VERSION_NAME: ${{ steps.build.outputs.version_name }}


### PR DESCRIPTION
Refs whu-ham/ham-workspace#9

## Problem

Every iOS release run published beta info to the docs site, including internal builds.

The step writes `docs/src/public/ios-beta.json`, which feeds `IOSDownloadPanel.vue` on the public download page, and it links to a hardcoded public TestFlight invite:

```bash
TESTFLIGHT_URL="itms-beta://testflight.apple.com/join/waKNnCG3"
```

An internal build goes only to the internal TestFlight group. Publishing it means an internal version number and its notes appear on the public download page alongside a public join link, for a build the public cannot get.

The `distribution` field was already available in the payload (`internal` or `public`, defaulting to `internal`), it just was not used to gate this step.

## Fix

Gate the publish step on `distribution == 'public'`. Internal builds now skip it.

Everything else is unchanged, so internal builds still advance the version: `Commit version bump` and `Notify iOS repository` run regardless, which is what the version-number bump depends on.

## Verification

Parsed the workflow and confirmed the condition lands on the right step:

```
'Commit version bump'            | if: None
'Publish beta info to the docs site' | if: "${{ github.event.client_payload.distribution == 'public' }}"
```

Both iOS workflow files parse as valid YAML.
