### PR TITLE
fix(ci): publish beta metadata through a pull request

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -13,8 +13,11 @@ jobs:
     runs-on: macos-latest
     permissions:
       # Write is required to push the version bump and the beta metadata back
-      # to this repository.
+      # to this repository, to open the beta metadata pull request, and to
+      # apply its label.
       contents: write
+      pull-requests: write
+      issues: write
     outputs:
       version_name: ${{ steps.build.outputs.version_name }}
       version_code: ${{ steps.build.outputs.version_code }}
@@ -295,7 +298,7 @@ jobs:
 
           # Checkout the docs site on a scratch path so the build workspace stays clean.
           DOCS_DIR="$RUNNER_TEMP/ham-docs"
-          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$DOCS_DIR"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$DOCS_DIR"
 
           mkdir -p "$DOCS_DIR/docs/src/public"
 
@@ -314,12 +317,57 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/src/public/ios-beta.json
-          if ! git diff --cached --quiet; then
-            git commit -m "chore(ios): publish beta ${VERSION_NAME} (${VERSION_CODE})"
-            git push origin HEAD:main
-          else
-            echo "Beta info unchanged, nothing to commit."
+          if git diff --cached --quiet; then
+            echo "Beta info unchanged, nothing to publish."
+            exit 0
           fi
+
+          # main is protected: changes must arrive through a pull request and
+          # pass the required eslint check. Push a branch and open a PR.
+          BRANCH="chore/ios-beta-${VERSION_NAME}-${VERSION_CODE}"
+          PR_TITLE="chore(ios): publish beta ${VERSION_NAME} (${VERSION_CODE})"
+          LABEL="ios-release"
+
+          git checkout -b "$BRANCH"
+          git commit -m "$PR_TITLE"
+          git push origin "HEAD:${BRANCH}"
+
+          # Create the label if it is missing. It may already exist, and the
+          # token may not be allowed to create it, so never fail on either.
+          gh label create "$LABEL" \
+            --repo "$GITHUB_REPOSITORY" \
+            --color "0E8A16" \
+            --description "Automated iOS TestFlight release metadata" || true
+
+          # Build the body in a file: the notes are user input and may contain
+          # quotes, backticks or backslashes.
+          BODY_FILE="$RUNNER_TEMP/beta-pr-body.md"
+          {
+            echo "Automated beta metadata for iOS ${VERSION_NAME} (${VERSION_CODE})."
+            echo
+            echo "Published by the iOS release workflow (run ${GITHUB_RUN_ID}). The version"
+            echo "was already uploaded to TestFlight, so this only refreshes"
+            echo "\`docs/src/public/ios-beta.json\` on the download page."
+          } > "$BODY_FILE"
+
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "$BRANCH" \
+            --title "$PR_TITLE" \
+            --label "$LABEL" \
+            --body-file "$BODY_FILE" || {
+            echo "::error::Failed to open the beta metadata pull request"
+            exit 1
+          }
+
+          # The ruleset requires a green eslint check and approves zero
+          # reviewers, so the PR can merge itself once that check passes.
+          gh pr merge "$BRANCH" \
+            --repo "$GITHUB_REPOSITORY" \
+            --squash \
+            --auto ||
+            echo "::warning::Could not enable auto-merge; merge the beta metadata PR manually."
 
       - name: Cleanup Keychain
         if: always()

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -361,13 +361,13 @@ jobs:
             exit 1
           }
 
-          # The ruleset requires a green eslint check and approves zero
-          # reviewers, so the PR can merge itself once that check passes.
-          gh pr merge "$BRANCH" \
-            --repo "$GITHUB_REPOSITORY" \
-            --squash \
-            --auto ||
-            echo "::warning::Could not enable auto-merge; merge the beta metadata PR manually."
+          # Do not enable auto-merge. GitHub holds workflow runs triggered by a
+          # GITHUB_TOKEN-created pull request for manual approval, so the
+          # required eslint check never turns green on its own and auto-merge
+          # would never fire. Leave the PR open for a human to merge, which
+          # also gives the release notes a review before they go public.
+          PR_URL=$(gh pr view "$BRANCH" --repo "$GITHUB_REPOSITORY" --json url --jq .url)
+          echo "::notice::Opened beta metadata PR: ${PR_URL}"
 
       - name: Cleanup Keychain
         if: always()


### PR DESCRIPTION
Refs whu-ham/ham-workspace#9

## Problem

The iOS release run at https://github.com/whu-ham/whu-ham.github.io/actions/runs/34295614769 failed on its last step, `Publish beta info to the docs site`:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Required status check "eslint" is expected.
! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

Everything before it had already succeeded, including `Build & Upload to TestFlight` and `Commit version bump`, so the version shipped but the download page never received the new metadata and the job was marked failed.

Note the two pushes in this job are not equivalent. `Commit version bump` pushes to `ham-ios` (the workspace checkout) and succeeds because that repo is unprotected. Only the docs step clones `whu-ham.github.io` and pushes there, which is what the ruleset blocks.

## Fix

Open a pull request instead of pushing to `main`:

- push a `chore/ios-beta-<version>-<build>` branch
- title it with a Conventional Commit carrying the version: `chore(ios): publish beta 1.7.6 (315)`
- apply the `ios-release` label, creating it first if needed (best-effort, since `github.token` may not be permitted to create labels)
- emit a notice with the PR URL

The `ios-release` label did not exist; it has been created in the repository.

## Why not auto-merge

The first version of this change enabled auto-merge, on the assumption that the required `eslint` check would turn green on its own. It would not.

GitHub holds workflow runs that a `GITHUB_TOKEN`-created pull request triggers for manual approval. From the docs on events that trigger workflows:

> When a pull request is created or updated by a workflow using `GITHUB_TOKEN`, `pull_request` events with the `opened`, `synchronize`, or `reopened` activity types create workflow runs that require approval.

So `gh pr create` succeeds and the PR exists, but the `Lint` run sits in `action_required`. The `eslint` status check never reports success, so auto-merge never fires and the PR stalls while looking automated.

The PR is therefore left open for a human to merge. That also gives the public-facing release notes a review before they go live. The step still succeeds, so a release is no longer marked failed over metadata that is one click from landing.

## Details

- The clone is no longer `--depth 1`; pushing a branch needs real history.
- The PR body is written to a file instead of interpolated inline, because the release notes are user input and may contain quotes, backticks or backslashes.
- Job permissions now include `pull-requests: write` (open the PR) and `issues: write` (apply the label). `bypass_actors` on the ruleset is `OrganizationAdmin` only, so the bot PR is fully subject to the rules.
- When the metadata is unchanged the step exits early without opening a PR.

## Verification

- `ios-release` label confirmed creatable in this repository.
- Read GitHub's documented `GITHUB_TOKEN` behaviour from `events-that-trigger-workflows` rather than assuming auto-merge would work; this is what removed the auto-merge.
- Ran the shell logic with stubbed `git`/`gh`: branch `chore/ios-beta-1.7.6-315`, title `chore(ios): publish beta 1.7.6 (315)` and body all render correctly; the title matches the Conventional Commit pattern.
- Both iOS workflow files parse as valid YAML.

## Note

This sits on top of the change gating this step on `distribution == 'public'`, so an internal build still publishes nothing.
