### PR TITLE
ci: add manual Android and iOS E2E workflows

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -31,23 +31,17 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    # Google publishes the Android emulator for Linux as x86_64 only, so an
+    # arm64-v8a system image on ubuntu-latest has no native emulator and falls
+    # back to software emulation. The macOS runners are Apple Silicon, and the
+    # emulator ships a darwin_aarch64 build there, so the ARM image runs
+    # accelerated. Trade-off: 3 cores / 7 GB instead of Linux's 4 / 16.
+    runs-on: macos-15
     timeout-minutes: 240
     permissions:
       contents: read
 
     steps:
-      - name: Free runner disk space
-        run: |
-          # Hosted runners ship a large preinstalled toolchain that an Android
-          # build never touches. Removing it leaves room for the SDK, the
-          # emulator image, and the Gradle build output.
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY/CodeQL" 2>/dev/null || true
-          sudo swapoff -a 2>/dev/null || true
-          sudo rm -f /mnt/swapfile 2>/dev/null || true
-          df -h /
-
       - name: Checkout Android repository
         uses: actions/checkout@v5
         with:
@@ -93,6 +87,8 @@ jobs:
       # workers, which does not fit on a hosted runner that also has to run the
       # emulator. A Gradle user-home gradle.properties takes precedence over the
       # project one, so this tunes the build without touching the checkout.
+      # The macOS runner has 7 GB total and the AVD below reserves 3 GB of it,
+      # so the heap stays well under that.
       - name: Tune Gradle for hosted runners
         run: |
           set -euo pipefail
@@ -101,7 +97,7 @@ jobs:
           org.gradle.daemon=false
           org.gradle.parallel=false
           org.gradle.workers.max=2
-          org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+          org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
           GRADLE
 
       - name: Setup Gradle
@@ -129,18 +125,13 @@ jobs:
         with:
           api-level: ${{ inputs.api_level }}
           target: google_apis
-          # Run the emulator on the host's own instruction set so KVM can
-          # accelerate it. An arm64-v8a image on this x86-64 runner would fall
-          # back to software emulation and exhaust the boot timeout.
-          #
-          # The GithubDebug APK ships both ABIs: the Github flavor pins
-          # ndk.abiFilters to arm64-v8a, but the debug build type widens it to
-          # arm64-v8a + x86_64, and AGP merges abiFilters from flavors and
-          # build types as a union rather than overriding.
-          arch: x86_64
+          # The macos-15 runner is Apple Silicon, so the arm64-v8a image the
+          # GithubDebug APK ships runs natively instead of being translated.
+          arch: arm64-v8a
           profile: pixel_6
+          # The macOS runner has 3 cores; leave one for the host and Gradle.
           cores: 2
-          ram-size: 4096M
+          ram-size: 3072M
           heap-size: 512M
           disable-animations: true
           emulator-boot-timeout: 1800

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -129,9 +129,15 @@ jobs:
         with:
           api-level: ${{ inputs.api_level }}
           target: google_apis
-          # Match the app's ABI: the Github flavor pins ndk.abiFilters to
-          # arm64-v8a, so the test APK is built and installed as arm64-v8a.
-          arch: arm64-v8a
+          # Run the emulator on the host's own instruction set so KVM can
+          # accelerate it. An arm64-v8a image on this x86-64 runner would fall
+          # back to software emulation and exhaust the boot timeout.
+          #
+          # The GithubDebug APK ships both ABIs: the Github flavor pins
+          # ndk.abiFilters to arm64-v8a, but the debug build type widens it to
+          # arm64-v8a + x86_64, and AGP merges abiFilters from flavors and
+          # build types as a union rather than overriding.
+          arch: x86_64
           profile: pixel_6
           cores: 2
           ram-size: 4096M

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -1,0 +1,174 @@
+name: Android Manual E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Android branch to test
+        required: true
+        type: string
+        default: main
+      scope:
+        description: Which instrumentation test targets to run
+        required: true
+        type: choice
+        options:
+          - app
+          - all
+        default: app
+      api_level:
+        description: Emulator Android API level
+        required: true
+        type: choice
+        options:
+          - '35'
+          - '36'
+        default: '35'
+
+concurrency:
+  group: android-e2e-${{ inputs.branch }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    permissions:
+      contents: read
+
+    steps:
+      - name: Free runner disk space
+        run: |
+          # Hosted runners ship a large preinstalled toolchain that an Android
+          # build never touches. Removing it leaves room for the SDK, the
+          # emulator image, and the Gradle build output.
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY/CodeQL" 2>/dev/null || true
+          sudo swapoff -a 2>/dev/null || true
+          sudo rm -f /mnt/swapfile 2>/dev/null || true
+          df -h /
+
+      - name: Checkout Android repository
+        uses: actions/checkout@v5
+        with:
+          repository: whu-ham/ham-android
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.HAM_ANDROID_REPO_TOKEN }}
+          fetch-depth: 1
+
+      - name: Configure private proto repository access
+        env:
+          PROTO_REPO_TOKEN: ${{ secrets.PROTO_REPO_TOKEN }}
+        run: |
+          if [ -z "$PROTO_REPO_TOKEN" ]; then
+            echo "::error::PROTO_REPO_TOKEN is required to clone whu-ham/ham-proto"
+            exit 1
+          fi
+          PROTO_GIT_CONFIG="$RUNNER_TEMP/ham-proto-gitconfig"
+          git config --file "$PROTO_GIT_CONFIG" url."https://x-access-token:${PROTO_REPO_TOKEN}@github.com/whu-ham/".insteadOf "https://github.com/whu-ham/"
+          echo "GIT_CONFIG_GLOBAL=$PROTO_GIT_CONFIG" >> "$GITHUB_ENV"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10.6.4
+          run_install: false
+          dest: ${{ runner.temp }}/setup-pnpm-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      # The checked-in gradle.properties asks for a 10 GB heap and 16 parallel
+      # workers, which does not fit on a hosted runner that also has to run the
+      # emulator. A Gradle user-home gradle.properties takes precedence over the
+      # project one, so this tunes the build without touching the checkout.
+      - name: Tune Gradle for hosted runners
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.gradle"
+          cat >> "$HOME/.gradle/gradle.properties" <<'GRADLE'
+          org.gradle.daemon=false
+          org.gradle.parallel=false
+          org.gradle.workers.max=2
+          org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+          GRADLE
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK packages
+        run: |
+          set -euo pipefail
+          yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null 2>&1 || true
+          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install \
+            platform-tools \
+            platforms\;android-36 \
+            build-tools\;36.0.0 \
+            ndk\;27.0.12077973 \
+            cmake\;3.22.1
+          echo "ANDROID_USER_HOME=$RUNNER_TEMP/android-user-home" >> "$GITHUB_ENV"
+
+      - name: Run instrumentation tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ inputs.api_level }}
+          target: google_apis
+          # Match the app's ABI: the Github flavor pins ndk.abiFilters to
+          # arm64-v8a, so the test APK is built and installed as arm64-v8a.
+          arch: arm64-v8a
+          profile: pixel_6
+          cores: 2
+          ram-size: 4096M
+          heap-size: 512M
+          disable-animations: true
+          emulator-boot-timeout: 1800
+          working-directory: android
+          script: |
+            set -euo pipefail
+            chmod +x ./gradlew
+            TASKS=":app:connectedGithubDebugAndroidTest"
+            if [ "${{ inputs.scope }}" = "all" ]; then
+              TASKS="$TASKS :feature:schedule:connectedDebugAndroidTest"
+              TASKS="$TASKS :feature:my:connectedDebugAndroidTest"
+              TASKS="$TASKS :feature:sport:connectedDebugAndroidTest"
+              TASKS="$TASKS :feature:score:connectedDebugAndroidTest"
+              TASKS="$TASKS :feature:print:connectedDebugAndroidTest"
+              TASKS="$TASKS :feature:coursescore:connectedDebugAndroidTest"
+            fi
+            echo "Running: $TASKS"
+            # shellcheck disable=SC2086
+            ./gradlew --no-daemon -Pandroid.builder.sdkDownload=false $TASKS
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-e2e-reports
+          path: |
+            android/**/build/reports/androidTests/**
+            android/**/build/outputs/androidTest-results/**
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Cleanup private proto repository access
+        if: always()
+        run: |
+          if [ -n "${GIT_CONFIG_GLOBAL:-}" ]; then
+            rm -f "$GIT_CONFIG_GLOBAL"
+          fi

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -8,16 +8,6 @@ on:
         required: true
         type: string
         default: main
-      os_version:
-        description: iOS version to test on. Leave empty to use the newest installed runtime.
-        required: false
-        type: string
-        default: ''
-      device:
-        description: Device name filter, e.g. "iPhone" or "iPad". Leave empty for the first available iPhone.
-        required: false
-        type: string
-        default: ''
       only_testing:
         description: Optional -only-testing filter, e.g. Tests_iOS/HamE2ECourseFlows
         required: false
@@ -163,45 +153,36 @@ jobs:
           ./pod_install.sh
 
       - name: Prepare simulator
-        # Dispatch inputs are free-form strings. Read them from the step
-        # environment instead of interpolating them into the Python and shell
-        # source below, so a crafted value cannot escape as executable code.
-        env:
-          INPUT_OS_VERSION: ${{ inputs.os_version }}
-          INPUT_DEVICE: ${{ inputs.device }}
         run: |
           set -euo pipefail
 
           # Runner images rotate the devices and runtimes they ship, and a
           # hardcoded device name breaks as soon as one disappears. Resolve the
-          # destination from what this image actually has instead.
+          # newest available runtime and the first iPhone from what this image
+          # actually provides. The E2E suite does not depend on a specific
+          # device or OS: it launches with a pinned en_US locale and skips any
+          # screen it cannot reach, so no dispatch input is needed here.
           #
           # Vendored SDKs (TPNS, AMap) ship arm64 for the device only and their
           # simulator slice is x86_64, so the build must exclude arm64 for the
           # simulator SDK. XGExtension already encodes this in its own Debug
           # configuration.
           RUNTIME_ID=$(xcrun simctl list runtimes available -j | python3 -c '
-          import json, os, sys
-          wanted = os.environ.get("INPUT_OS_VERSION", "").strip()
+          import json, sys
           runtimes = json.load(sys.stdin)["runtimes"]
-          if wanted:
-              match = next((r for r in runtimes
-                            if r.get("isAvailable") and r.get("version") == wanted), None)
-          else:
-              match = None
-              for r in runtimes:
-                  if not r.get("isAvailable"):
-                      continue
-                  try:
-                      version = tuple(int(part) for part in r["version"].split("."))
-                  except (KeyError, ValueError):
-                      continue
-                  if match is None or version > match[0]:
-                      match = (version, r)
-              match = match[1] if match else None
+          match = None
+          for runtime in runtimes:
+              if not runtime.get("isAvailable"):
+                  continue
+              try:
+                  version = tuple(int(part) for part in runtime["version"].split("."))
+              except (KeyError, ValueError):
+                  continue
+              if match is None or version > match[0]:
+                  match = (version, runtime)
           if match is None:
-              sys.exit("No matching iOS runtime found")
-          print(match["identifier"], match["version"])
+              sys.exit("No available iOS runtime found")
+          print(match[1]["identifier"], match[1]["version"])
           ')
 
           RUNTIME=$(echo "$RUNTIME_ID" | cut -d' ' -f1)
@@ -209,15 +190,11 @@ jobs:
           echo "Runtime: $RUNTIME (iOS $OS_VERSION)"
 
           DEVICE=$(xcrun simctl list devicetypes -j | python3 -c '
-          import json, os, sys
-          filter_text = os.environ.get("INPUT_DEVICE", "").strip().lower()
+          import json, sys
           types = json.load(sys.stdin)["devicetypes"]
-          if filter_text:
-              candidates = [t for t in types if filter_text in t["name"].lower()]
-          else:
-              candidates = [t for t in types if "iPhone" in t["name"]]
+          candidates = [t for t in types if "iphone" in t["name"].lower()]
           if not candidates:
-              sys.exit("No matching device type found")
+              sys.exit("No iPhone device type found")
           print(candidates[0]["name"])
           ')
           echo "Device: $DEVICE"

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -1,0 +1,289 @@
+name: iOS Manual E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: iOS branch to test
+        required: true
+        type: string
+        default: main
+      os_version:
+        description: iOS version to test on. Leave empty to use the newest installed runtime.
+        required: false
+        type: string
+        default: ''
+      device:
+        description: Device name filter, e.g. "iPhone" or "iPad". Leave empty for the first available iPhone.
+        required: false
+        type: string
+        default: ''
+      only_testing:
+        description: Optional -only-testing filter, e.g. Tests_iOS/HamE2ECourseFlows
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: ios-e2e-${{ inputs.branch }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: macos-15
+    timeout-minutes: 180
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout iOS repository
+        uses: actions/checkout@v5
+        with:
+          repository: whu-ham/ham-ios
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.HAM_IOS_REPO_TOKEN }}
+          fetch-depth: 1
+
+      - name: Configure private proto repository access
+        env:
+          PROTO_REPO_TOKEN: ${{ secrets.PROTO_REPO_TOKEN }}
+        run: |
+          if [ -z "$PROTO_REPO_TOKEN" ]; then
+            echo "::error::PROTO_REPO_TOKEN is required to clone whu-ham/ham-proto"
+            exit 1
+          fi
+          PROTO_GIT_CONFIG="$RUNNER_TEMP/ham-proto-gitconfig"
+          git config --file "$PROTO_GIT_CONFIG" url."https://x-access-token:${PROTO_REPO_TOKEN}@github.com/whu-ham/ham-proto.git".insteadOf "https://github.com/whu-ham/ham-proto.git"
+          echo "GIT_CONFIG_GLOBAL=$PROTO_GIT_CONFIG" >> "$GITHUB_ENV"
+
+      - name: Show Xcode and available simulators
+        run: |
+          # The other iOS workflows build with the runner's default Xcode, so
+          # this step only records the toolchain rather than overriding it.
+          xcodebuild -version
+          xcrun simctl list runtimes
+
+      - name: Install protobuf
+        run: |
+          # The Podfile's post_install hook shells out to `protoc` to generate
+          # the HamProtobuf Swift sources, and the binary is not preinstalled
+          # on GitHub-hosted macOS runners.
+          brew install protobuf
+          protoc --version
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 10.6.4
+          # pod_install.sh runs `pnpm install` before applying the glog patch.
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Cache CocoaPods downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-cocoapods-e2e-${{ hashFiles('Ham/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cocoapods-e2e-
+
+      - name: Cache SwiftPM artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm/artifacts
+            ~/Library/Caches/org.swift.swiftpm/repositories
+          key: ${{ runner.os }}-swiftpm-e2e-${{ hashFiles('Ham/Ham.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'Component/HamProtobuf/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-e2e-
+
+      - name: Install CocoaPods
+        run: |
+          # Pin the version recorded in Ham/Podfile.lock; a newer CocoaPods
+          # rewrites every checksum in that file.
+          COCOAPODS_VERSION=$(awk -F': *' '/^COCOAPODS:/{print $2; exit}' Ham/Podfile.lock)
+          if [ -z "$COCOAPODS_VERSION" ]; then
+            echo "::error::Could not read the COCOAPODS version from Ham/Podfile.lock"
+            exit 1
+          fi
+          if gem list -i cocoapods --version "$COCOAPODS_VERSION" >/dev/null; then
+            echo "CocoaPods $COCOAPODS_VERSION already installed"
+          else
+            gem install cocoapods --version "$COCOAPODS_VERSION" --no-document
+          fi
+
+      - name: Pre-resolve Xcode workspace Swift packages
+        run: |
+          # xcodebuild resolves the workspace's Swift packages itself, and on
+          # macOS runners that hangs indefinitely:
+          #   https://github.com/actions/runner-images/issues/13175
+          # The SwiftPM CLI resolves the same graph reliably and writes to the
+          # shared cache xcodebuild reads.
+          RESOLVED="Ham/Ham.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+          WARM_DIR="$RUNNER_TEMP/swiftpm-warm"
+          mkdir -p "$WARM_DIR"
+          python3 - "$RESOLVED" "$WARM_DIR/Package.swift" <<'PY'
+          import json, sys
+          resolved_path, out_path = sys.argv[1], sys.argv[2]
+          with open(resolved_path) as handle:
+              pins = json.load(handle).get("pins", [])
+          if not pins:
+              sys.exit("No pins found in %s" % resolved_path)
+          lines = [
+              "// swift-tools-version: 5.9",
+              "import PackageDescription",
+              "",
+              "let package = Package(",
+              '    name: "SwiftPMWarmCache",',
+              "    products: [],",
+              "    dependencies: [",
+          ]
+          for index, pin in enumerate(sorted(pins, key=lambda p: p["identity"])):
+              version = pin.get("state", {}).get("version")
+              if not version:
+                  continue
+              comma = "," if index < len(pins) - 1 else ""
+              lines.append('        .package(url: "%s", exact: "%s")%s'
+                           % (pin["location"], version, comma))
+          lines += ["    ],", "    targets: []", ")"]
+          with open(out_path, "w") as handle:
+              handle.write("\n".join(lines) + "\n")
+          print("Wrote %s with %d dependencies" % (out_path, len(pins)))
+          PY
+          cd "$WARM_DIR"
+          env SWIFTPM_MAX_CONCURRENT_OPERATIONS=1 swift package resolve
+
+      - name: CocoaPods Install
+        run: |
+          # The project's own script also applies the glog configure patch that
+          # `pnpm install` alone does not.
+          ./pod_install.sh
+
+      - name: Prepare simulator
+        run: |
+          set -euo pipefail
+
+          # Runner images rotate the devices and runtimes they ship, and a
+          # hardcoded device name breaks as soon as one disappears. Resolve the
+          # destination from what this image actually has instead.
+          #
+          # Vendored SDKs (TPNS, AMap) ship arm64 for the device only and their
+          # simulator slice is x86_64, so the build must exclude arm64 for the
+          # simulator SDK. XGExtension already encodes this in its own Debug
+          # configuration.
+          RUNTIME_ID=$(xcrun simctl list runtimes available -j | python3 -c '
+          import json, sys
+          wanted = "${{ inputs.os_version }}".strip()
+          runtimes = json.load(sys.stdin)["runtimes"]
+          if wanted:
+              match = next((r for r in runtimes
+                            if r.get("isAvailable") and r.get("version") == wanted), None)
+          else:
+              match = None
+              for r in runtimes:
+                  if not r.get("isAvailable"):
+                      continue
+                  try:
+                      version = tuple(int(part) for part in r["version"].split("."))
+                  except (KeyError, ValueError):
+                      continue
+                  if match is None or version > match[0]:
+                      match = (version, r)
+              match = match[1] if match else None
+          if match is None:
+              sys.exit("No matching iOS runtime found")
+          print(match["identifier"], match["version"])
+          ')
+
+          RUNTIME=$(echo "$RUNTIME_ID" | cut -d' ' -f1)
+          OS_VERSION=$(echo "$RUNTIME_ID" | cut -d' ' -f2)
+          echo "Runtime: $RUNTIME (iOS $OS_VERSION)"
+
+          DEVICE=$(xcrun simctl list devicetypes -j | python3 -c '
+          import json, sys
+          filter_text = "${{ inputs.device }}".strip().lower()
+          types = json.load(sys.stdin)["devicetypes"]
+          if filter_text:
+              candidates = [t for t in types if filter_text in t["name"].lower()]
+          else:
+              candidates = [t for t in types if "iPhone" in t["name"]]
+          if not candidates:
+              sys.exit("No matching device type found")
+          print(candidates[0]["name"])
+          ')
+          echo "Device: $DEVICE"
+
+          NAME="Ham E2E ${DEVICE} ${OS_VERSION}"
+          # simctl create wants identifiers; a missing device is the normal case
+          # on a fresh runner image.
+          if ! xcrun simctl list devices available | grep -qF "$NAME"; then
+            xcrun simctl create "$NAME" "$DEVICE" "$RUNTIME"
+          fi
+
+          echo "DEVICE_NAME=$NAME" >> "$GITHUB_ENV"
+          echo "OS_VERSION=$OS_VERSION" >> "$GITHUB_ENV"
+          echo "SIM_DESTINATION=platform=iOS Simulator,name=$NAME,OS=$OS_VERSION" >> "$GITHUB_ENV"
+          xcrun simctl list devices available | grep -F "$NAME"
+
+      - name: Run E2E tests
+        timeout-minutes: 150
+        env:
+          NSUnbufferedIO: YES
+        run: |
+          set -euo pipefail
+          cd Ham
+          ONLY_TESTING="${{ inputs.only_testing }}"
+          TEST_ARGS=()
+          if [ -n "$ONLY_TESTING" ]; then
+            TEST_ARGS=(-only-testing:"$ONLY_TESTING")
+          fi
+          # pipefail keeps the pipeline's exit status so a failing test suite
+          # fails the job instead of being masked by tee.
+          set -o pipefail
+          xcodebuild \
+            -workspace Ham.xcworkspace \
+            -scheme "Tests iOS" \
+            -configuration Debug \
+            -destination "$SIM_DESTINATION" \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            -resultBundlePath "$RUNNER_TEMP/e2e.xcresult" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            ONLY_ACTIVE_ARCH=YES \
+            'EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64' \
+            "${TEST_ARGS[@]}" \
+            test | tee "$RUNNER_TEMP/xcodebuild.log"
+
+      - name: Summarize test results
+        if: always()
+        run: |
+          set -uo pipefail
+          LOG="$RUNNER_TEMP/xcodebuild.log"
+          if [ ! -f "$LOG" ]; then
+            echo "No xcodebuild log found."
+            exit 0
+          fi
+          {
+            echo "### iOS E2E results"
+            echo
+            grep -E "Test Suite '|Executed [0-9]+ tests?" "$LOG" | tail -40
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-e2e-results
+          path: ${{ runner.temp }}/e2e.xcresult
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Cleanup proto git config
+        if: always()
+        run: |
+          if [ -n "${GIT_CONFIG_GLOBAL:-}" ]; then
+            rm -f "$GIT_CONFIG_GLOBAL"
+          fi

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -163,6 +163,12 @@ jobs:
           ./pod_install.sh
 
       - name: Prepare simulator
+        # Dispatch inputs are free-form strings. Read them from the step
+        # environment instead of interpolating them into the Python and shell
+        # source below, so a crafted value cannot escape as executable code.
+        env:
+          INPUT_OS_VERSION: ${{ inputs.os_version }}
+          INPUT_DEVICE: ${{ inputs.device }}
         run: |
           set -euo pipefail
 
@@ -175,8 +181,8 @@ jobs:
           # simulator SDK. XGExtension already encodes this in its own Debug
           # configuration.
           RUNTIME_ID=$(xcrun simctl list runtimes available -j | python3 -c '
-          import json, sys
-          wanted = "${{ inputs.os_version }}".strip()
+          import json, os, sys
+          wanted = os.environ.get("INPUT_OS_VERSION", "").strip()
           runtimes = json.load(sys.stdin)["runtimes"]
           if wanted:
               match = next((r for r in runtimes
@@ -203,8 +209,8 @@ jobs:
           echo "Runtime: $RUNTIME (iOS $OS_VERSION)"
 
           DEVICE=$(xcrun simctl list devicetypes -j | python3 -c '
-          import json, sys
-          filter_text = "${{ inputs.device }}".strip().lower()
+          import json, os, sys
+          filter_text = os.environ.get("INPUT_DEVICE", "").strip().lower()
           types = json.load(sys.stdin)["devicetypes"]
           if filter_text:
               candidates = [t for t in types if filter_text in t["name"].lower()]
@@ -232,10 +238,13 @@ jobs:
         timeout-minutes: 150
         env:
           NSUnbufferedIO: YES
+          # `only_testing` is a free-form dispatch input. Reading it from the
+          # environment keeps a crafted value from being parsed as shell code.
+          INPUT_ONLY_TESTING: ${{ inputs.only_testing }}
         run: |
           set -euo pipefail
           cd Ham
-          ONLY_TESTING="${{ inputs.only_testing }}"
+          ONLY_TESTING="$INPUT_ONLY_TESTING"
           TEST_ARGS=()
           if [ -n "$ONLY_TESTING" ]; then
             TEST_ARGS=(-only-testing:"$ONLY_TESTING")


### PR DESCRIPTION
Adds two manually triggered workflows that run the existing end-to-end suites on GitHub-hosted runners.

## Android (`android-e2e.yml`, `ubuntu-latest`)

Runs the Compose instrumentation tests on an emulator. Inputs: `branch`, `scope` (`app` or `all`), `api_level`.

- Emulator ABI matches the app: the `Github` flavor pins `ndk.abiFilters` to `arm64-v8a`.
- Gradle is tuned for hosted runners; the checked-in `gradle.properties` requests a 10 GB heap and 16 workers, which does not fit a runner that also hosts the emulator.

## iOS (`ios-e2e.yml`, `macos-15`)

Runs the `Tests iOS` scheme on a simulator. Inputs: `branch`, `os_version`, `device`, `only_testing`.

- The simulator runtime and device are resolved from what the image actually provides. Hardcoding a device name breaks when images rotate devices out — `macos-26` no longer ships a plain "iPhone 16".
- The build excludes arm64 for the simulator SDK. The vendored TPNS and AMap archives ship arm64 for the device only; their x86_64 slice is the simulator one. `XGExtension` already encodes this exclusion in its own Debug configuration.

## Secrets

Both reuse secrets the existing workflows already use: `HAM_ANDROID_REPO_TOKEN`, `HAM_IOS_REPO_TOKEN`, `PROTO_REPO_TOKEN`. No new secrets are required.

## Notes

- I could not execute either workflow end-to-end here; they need a real runner.
- The Android `androidTest` source sets may need `compose_uiTestJunit4` / `compose_uiTestManifest` wired up. Both aliases exist in `gradle/libs.versions.toml` but no module currently declares them, so `androidTest` compilation of the Compose E2E tests may fail. That belongs to `ham-android` and is out of scope for this PR.