### PR TITLE
fix(ci): run Android E2E on Linux x86_64 and fix empty iOS test args

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -31,17 +31,28 @@ concurrency:
 
 jobs:
   e2e:
-    # Google publishes the Android emulator for Linux as x86_64 only, so an
-    # arm64-v8a system image on ubuntu-latest has no native emulator and falls
-    # back to software emulation. The macOS runners are Apple Silicon, and the
-    # emulator ships a darwin_aarch64 build there, so the ARM image runs
-    # accelerated. Trade-off: 3 cores / 7 GB instead of Linux's 4 / 16.
-    runs-on: macos-15
+    # Google publishes the Android emulator for Linux as x86_64 only, and the
+    # Linux runners expose KVM, so the x86_64 system image boots accelerated.
+    # The emulator also ships a darwin_aarch64 build, but hosted macOS runners
+    # deny nested virtualization: the ARM emulator dies immediately with
+    # "HVF error: HV_UNSUPPORTED" and the AVD never comes online.
+    runs-on: ubuntu-latest
     timeout-minutes: 240
     permissions:
       contents: read
 
     steps:
+      - name: Free runner disk space
+        run: |
+          # Hosted runners ship a large preinstalled toolchain that an Android
+          # build never touches. Removing it leaves room for the SDK, the
+          # emulator image, and the Gradle build output.
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY/CodeQL" 2>/dev/null || true
+          sudo swapoff -a 2>/dev/null || true
+          sudo rm -f /mnt/swapfile 2>/dev/null || true
+          df -h /
+
       - name: Checkout Android repository
         uses: actions/checkout@v5
         with:
@@ -87,7 +98,7 @@ jobs:
       # workers, which does not fit on a hosted runner that also has to run the
       # emulator. A Gradle user-home gradle.properties takes precedence over the
       # project one, so this tunes the build without touching the checkout.
-      # The macOS runner has 7 GB total and the AVD below reserves 3 GB of it,
+      # The Linux runner has 16 GB total and the AVD below reserves 4 GB of it,
       # so the heap stays well under that.
       - name: Tune Gradle for hosted runners
         run: |
@@ -97,7 +108,7 @@ jobs:
           org.gradle.daemon=false
           org.gradle.parallel=false
           org.gradle.workers.max=2
-          org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+          org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
           GRADLE
 
       - name: Setup Gradle
@@ -125,16 +136,19 @@ jobs:
         with:
           api-level: ${{ inputs.api_level }}
           target: google_apis
-          # The macos-15 runner is Apple Silicon, so the arm64-v8a image the
-          # GithubDebug APK ships runs natively instead of being translated.
-          arch: arm64-v8a
+          # GithubDebug keeps both arm64-v8a and x86_64: the Github flavor pins
+          # arm64-v8a and the debug build type adds x86_64, and AGP merges
+          # abiFilters as a union. The x86_64 slice is what this emulator runs.
+          arch: x86_64
           profile: pixel_6
-          # The macOS runner has 3 cores; leave one for the host and Gradle.
+          # The Linux runner has 4 cores; leave two for the host and Gradle.
           cores: 2
-          ram-size: 3072M
+          ram-size: 4096M
           heap-size: 512M
           disable-animations: true
-          emulator-boot-timeout: 1800
+          # A boot failure leaves adb polling against a dead emulator, so cap
+          # the wait well below the job timeout and let the step fail fast.
+          emulator-boot-timeout: 600
           working-directory: android
           script: |
             set -euo pipefail

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -161,23 +161,24 @@ jobs:
           # the wait well below the job timeout and let the step fail fast.
           emulator-boot-timeout: 600
           working-directory: android
-          # The action runs this via `sh -c`, not bash, so bash-only shell
-          # options are illegal here. `set -o pipefail` fails the step with
-          # "set: Illegal option -o pipefail" before Gradle ever starts.
-          script: |
-            set -eu
-            chmod +x ./gradlew
-            TASKS=":app:connectedGithubDebugAndroidTest"
+          # Keep this a single logical line. script-parser.ts splits the value
+          # on newlines and runs each line as its own `sh -c`, so variables do
+          # not survive across lines, multi-line `if`/`fi` blocks fail to
+          # parse, and `#` comment lines are dropped. `sh` is dash on Ubuntu,
+          # so `set -o pipefail` is illegal here too.
+          script: >-
+            chmod +x ./gradlew &&
+            TASKS=":app:connectedGithubDebugAndroidTest" &&
             if [ "${{ inputs.scope }}" = "all" ]; then
-              TASKS="$TASKS :feature:schedule:connectedDebugAndroidTest"
-              TASKS="$TASKS :feature:my:connectedDebugAndroidTest"
-              TASKS="$TASKS :feature:sport:connectedDebugAndroidTest"
-              TASKS="$TASKS :feature:score:connectedDebugAndroidTest"
-              TASKS="$TASKS :feature:print:connectedDebugAndroidTest"
-              TASKS="$TASKS :feature:coursescore:connectedDebugAndroidTest"
-            fi
-            echo "Running: $TASKS"
-            # shellcheck disable=SC2086
+            TASKS="$TASKS
+            :feature:schedule:connectedDebugAndroidTest
+            :feature:my:connectedDebugAndroidTest
+            :feature:sport:connectedDebugAndroidTest
+            :feature:score:connectedDebugAndroidTest
+            :feature:print:connectedDebugAndroidTest
+            :feature:coursescore:connectedDebugAndroidTest";
+            fi &&
+            echo "Running: $TASKS" &&
             ./gradlew --no-daemon -Pandroid.builder.sdkDownload=false $TASKS
 
       - name: Upload test reports

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -161,8 +161,11 @@ jobs:
           # the wait well below the job timeout and let the step fail fast.
           emulator-boot-timeout: 600
           working-directory: android
+          # The action runs this via `sh -c`, not bash, so bash-only shell
+          # options are illegal here. `set -o pipefail` fails the step with
+          # "set: Illegal option -o pipefail" before Gradle ever starts.
           script: |
-            set -euo pipefail
+            set -eu
             chmod +x ./gradlew
             TASKS=":app:connectedGithubDebugAndroidTest"
             if [ "${{ inputs.scope }}" = "all" ]; then

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -42,6 +42,17 @@ jobs:
       contents: read
 
     steps:
+      - name: Enable KVM group perms
+        run: |
+          # The emulator action probes /dev/kvm and silently falls back to
+          # `-accel off` when the runner user cannot open it. Software-emulated
+          # x86_64 then never finishes booting inside the timeout. Granting
+          # group access here is the setup the action's README requires for
+          # hardware acceleration on Linux runners.
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Free runner disk space
         run: |
           # Hosted runners ship a large preinstalled toolchain that an Android

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -229,6 +229,14 @@ jobs:
           # pipefail keeps the pipeline's exit status so a failing test suite
           # fails the job instead of being masked by tee.
           set -o pipefail
+          # Pass EXCLUDED_ARCHS in the plain `SETTING=value` form. The
+          # SDK-conditional spelling `EXCLUDED_ARCHS[sdk=iphonesimulator*]`
+          # does not survive the command line: xcodebuild splits on the first
+          # `=` and records it as `EXCLUDED_ARCHS = iphonesimulator*]=arm64`,
+          # so the exclusion silently never applies and the device-only arm64
+          # slice of the vendored XGExtension archive breaks the simulator
+          # link. This build targets the simulator only, so the unconditional
+          # setting is equivalent here and actually takes effect.
           xcodebuild \
             -workspace Ham.xcworkspace \
             -scheme "Tests iOS" \
@@ -239,7 +247,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             ONLY_ACTIVE_ARCH=YES \
-            'EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64' \
+            EXCLUDED_ARCHS=arm64 \
             ${TEST_ARGS[@]+"${TEST_ARGS[@]}"} \
             test | tee "$RUNNER_TEMP/xcodebuild.log"
 

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -224,7 +224,7 @@ jobs:
           ONLY_TESTING="$INPUT_ONLY_TESTING"
           TEST_ARGS=()
           if [ -n "$ONLY_TESTING" ]; then
-            TEST_ARGS=(-only-testing:"$ONLY_TESTING")
+            TEST_ARGS+=(-only-testing:"$ONLY_TESTING")
           fi
           # pipefail keeps the pipeline's exit status so a failing test suite
           # fails the job instead of being masked by tee.
@@ -240,7 +240,7 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             ONLY_ACTIVE_ARCH=YES \
             'EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64' \
-            "${TEST_ARGS[@]}" \
+            ${TEST_ARGS[@]+"${TEST_ARGS[@]}"} \
             test | tee "$RUNNER_TEMP/xcodebuild.log"
 
       - name: Summarize test results


### PR DESCRIPTION
Follow-up to #96. Both manual E2E workflows failed on their first real run.

## Android: ARM emulator cannot start on macOS runners

`macos-15` was chosen in #96 because Google publishes a native `darwin_aarch64`
emulator build. That reasoning was incomplete: hosted macOS runners **deny nested
virtualization**, so the emulator exits immediately:

```
HVF error: HV_UNSUPPORTED
qemu-system-aarch64-headless: failed to initialize HVF: Invalid argument
WARNING | QEMU main loop exits abnormally with code 1
```

The AVD never comes online, and the workflow polled adb against a dead emulator
for ~30 minutes until the run was cancelled by hand.

Fix: return to `ubuntu-latest` with the `x86_64` system image, which KVM
accelerates natively. This works because `GithubDebug` ships an `x86_64` slice —
the Github flavor pins `arm64-v8a` and the `debug` build type adds `x86_64`, and
AGP merges `abiFilters` as a union. Verified on the built APK:

```
lib/arm64-v8a
lib/x86_64
```

Also cap `emulator-boot-timeout` at 600s (was 1800) so a boot failure fails fast
instead of stalling to the job timeout, and restore the Linux-only disk cleanup
step and 4 GB Gradle heap.

## iOS: empty array expansion crashes under `set -u`

The runner's `/bin/bash` is 3.2, where `"${ARRAY[@]}"` on an **empty** array with
`set -u` raises `unbound variable`. With no `only_testing` input — the default —
the step died in under a second, before `xcodebuild` ever ran:

```
line 12: TEST_ARGS[@]: unbound variable
##[error]Process completed with exit code 1.
```

Fix: use the portable `${ARR[@]+"${ARR[@]}"}` expansion. Verified locally on
bash 3.2 for both the empty and populated cases, and confirmed the value is still
passed as a single literal argument, so the injection guard from #96 holds.

## Known remaining blocker

The Android run also needs `assembleGithubDebugAndroidTest` to build, which
currently fails in `ham-android` — tracked separately, out of scope here.