### PR TITLE
fix(ci): stop the Android E2E runner from being OOM killed

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -58,10 +58,16 @@ jobs:
           # Hosted runners ship a large preinstalled toolchain that an Android
           # build never touches. Removing it leaves room for the SDK, the
           # emulator image, and the Gradle build output.
+          #
+          # Keep swap enabled. Disabling it here used to be cargo-culted in
+          # from the usual disk-space snippets, but this job is memory-bound
+          # rather than disk-bound: the emulator reserves 3G and Gradle peaks
+          # well above its heap while running CMake, KSP and Dex. With swap
+          # off, memory pressure is resolved by the kernel OOM killer, which
+          # tears down the whole runner mid-build. With swap on, the same
+          # pressure degrades to paging instead.
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost
           sudo rm -rf "$AGENT_TOOLSDIRECTORY/CodeQL" 2>/dev/null || true
-          sudo swapoff -a 2>/dev/null || true
-          sudo rm -f /mnt/swapfile 2>/dev/null || true
           df -h /
 
       - name: Checkout Android repository
@@ -109,8 +115,11 @@ jobs:
       # workers, which does not fit on a hosted runner that also has to run the
       # emulator. A Gradle user-home gradle.properties takes precedence over the
       # project one, so this tunes the build without touching the checkout.
-      # The Linux runner has 16 GB total and the AVD below reserves 4 GB of it,
-      # so the heap stays well under that.
+      #
+      # The Linux runner has 16 GB total. The AVD below reserves 3 GB, and the
+      # build's real peaks come from parallel CMake/Clang, KSP and Dex workers
+      # rather than from the Gradle heap alone, so cap the heap at 3 GB and cap
+      # worker count to keep the combined ceiling well under the machine.
       - name: Tune Gradle for hosted runners
         run: |
           set -euo pipefail
@@ -119,7 +128,7 @@ jobs:
           org.gradle.daemon=false
           org.gradle.parallel=false
           org.gradle.workers.max=2
-          org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+          org.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8
           GRADLE
 
       - name: Setup Gradle
@@ -154,7 +163,9 @@ jobs:
           profile: pixel_6
           # The Linux runner has 4 cores; leave two for the host and Gradle.
           cores: 2
-          ram-size: 4096M
+          # 3 GB rather than 4: the emulator and the Gradle build have to fit
+          # in 16 GB together, and the build's own peak is what pushes it over.
+          ram-size: 3072M
           heap-size: 512M
           disable-animations: true
           # A boot failure leaves adb polling against a dead emulator, so cap


### PR DESCRIPTION
Follow-up to #97. The Android E2E job got as far as building the app and then died 15 minutes in.

## The failure

```
> Task :app:buildCMakeDebug[arm64-v8a]
##[error]The runner has received a shutdown signal.
Cleaning up orphan processes
Terminate orphan process: pid (2962) (qemu-system-x86_64-headless)
```

The log is truncated with no `BUILD FAILED` and no JVM stack, the emulator is
reaped as an orphan process, and the job is nowhere near its 240-minute
timeout. That is the kernel OOM killer taking the runner out from under the
build, not a build error — which is why grepping the log for `out of memory`
finds nothing: the JVM never gets a chance to print anything.

## Why it ran out of memory

The job is memory-bound, not disk-bound. The AVD reserved 4 GB on a 16 GB
runner, and Gradle ran alongside it with a 4 GB heap plus parallel CMake,
KSP and Dex workers, whose peaks are separate from the Gradle heap.

The `Free runner disk space` step then removed the only remaining safety net:

```sh
sudo swapoff -a 2>/dev/null || true
sudo rm -f /mnt/swapfile 2>/dev/null || true
```

Those two lines were carried over from the usual disk-space snippets and have
been in this workflow since it was first added in #96. On this job they turn
memory pressure from "paging, therefore slower" into "OOM kill, therefore the
runner dies".

## Changes

- Stop disabling swap. Keep the actual disk cleanup.
- Gradle heap `-Xmx4g` -> `-Xmx3g`.
- AVD `ram-size` `4096M` -> `3072M`.

Together these put the combined ceiling comfortably under the 16 GB runner
and give the job somewhere to go when it spikes.

## Validation

Not yet re-run end to end. The previous run got past the emulator boot
(`Boot completed in 33052 ms`) and deep into the Gradle build before dying,
so all the earlier fixes are holding; this one only addresses the memory
ceiling. I will kick off a run once this is merged.
