### PR TITLE
ci: run iOS E2E on macos-latest

### DIFF
--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: macos-15
+    runs-on: macos-latest
     timeout-minutes: 180
     permissions:
       contents: read


### PR DESCRIPTION
The iOS Manual E2E workflow pinned `macos-15` while `ios-build` and `ios-release` both use `macos-latest`, so the E2E job stayed on a frozen image as the other two tracked new runner releases.

Switching to `macos-latest` keeps the three iOS workflows on the same runner image. This job already resolves its simulator runtime and device type at run time from what the image provides (see the "Prepare simulator" step), so it has no dependency on a specific macOS version — but it does depend on a recent Xcode, which `macos-latest` is the one that ships.

One line changed: `runs-on: macos-15` -> `runs-on: macos-latest`.

Ref: https://github.com/whu-ham/whu-ham.github.io/actions/runs/34364431824